### PR TITLE
Remove port expose from docker

### DIFF
--- a/packages/api/docker/Dockerfile
+++ b/packages/api/docker/Dockerfile
@@ -26,5 +26,4 @@ RUN npm install -g pnpm
 # Only install dependencies for production (ignore "devDependecies" section in package.json).
 RUN pnpm install --prod
 
-EXPOSE 3000
 CMD [ "node", "dist/src/local-server.js" ]


### PR DESCRIPTION
There is no need to expose docker port, since that is mainly for documentation purposes and we allow configuring the port number so I'd even say it's confusing.