### PR TITLE
Run signed API together with pusher

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,9 +2,10 @@
 
 A service for storing and accessing signed data. It provides endpoints to handle signed data for a specific airnode.
 
-## Configuration
+## Local development
 
-Copy `.env` from the `example.env` file and optionally change the defaults.
+1. `cp .env.example .env` - To copy `.env` from the `example.env` file. Optionally change the defaults.
+2. `pnpm run dev` - To start the API server. The port number can be configured in the `.env` file.
 
 ## Deployment
 

--- a/packages/api/src/evm.ts
+++ b/packages/api/src/evm.ts
@@ -13,15 +13,6 @@ const packAndHashWithTemplateId = (templateId: string, timestamp: string, data: 
 export const deriveBeaconId = (airnode: string, templateId: string) =>
   ethers.utils.keccak256(ethers.utils.solidityPack(['address', 'bytes32'], [airnode, templateId]));
 
-export const signWithTemplateId = (airnodeWallet: ethers.Wallet, templateId: string, timestamp: string, data: string) =>
-  airnodeWallet.signMessage(
-    ethers.utils.arrayify(
-      ethers.utils.keccak256(
-        ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data || '0x'])
-      )
-    )
-  );
-
 export const recoverSignerAddress = (data: SignedData): string => {
   const digest = packAndHashWithTemplateId(data.templateId, data.timestamp, data.encodedValue);
   return ethers.utils.verifyMessage(digest, data.signature);

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -12,6 +12,9 @@ export const startServer = () => {
   app.use(express.json());
 
   app.put('/', async (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('Received request "PUT /"', req.body, req.params, req.query);
+
     const result = await upsertData({
       body: JSON.stringify(req.body),
       queryParams: {},
@@ -20,6 +23,9 @@ export const startServer = () => {
   });
 
   app.post('/', async (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('Received request "POST /"', req.body, req.params, req.query);
+
     const result = await batchUpsertData({
       body: JSON.stringify(req.body),
       queryParams: {},
@@ -28,6 +34,9 @@ export const startServer = () => {
   });
 
   app.get('/:airnode', async (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('Received request "GET /:airnode"', req.body, req.params, req.query);
+
     const result = await getData({
       body: '',
       queryParams: { airnode: req.params.airnode },
@@ -36,6 +45,9 @@ export const startServer = () => {
   });
 
   app.get('/', async (_req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('Received request "GET /"');
+
     const result = await listAirnodeAddresses({
       body: '',
       queryParams: {},

--- a/packages/data-pusher/README.md
+++ b/packages/data-pusher/README.md
@@ -4,7 +4,20 @@ A service for storing and accessing signed data.
 
 ## Local development
 
-TODO: How to run locally.
+The pusher needs a configuration in order to run. The `config` folder contains example configuration which uses:
+
+- [Nodary](https://nodary.io/) as the data provider, from which the data is fetched.
+- Signed API running on `http://localhost:8090` where the data is pushed.
+
+To start the the pusher in dev mode run the following:
+
+1. `cp pusher.example.json pusher.json` - To copy the pusher configuration from the example. Note, the `pusher.json`
+   file is ignored by git.
+2. `cp secrets.example.env secrets.env` - To copy the secrets.env needed for the configuration. This file is also
+   ignored by git.
+3. Set the `NODARY_API_KEY` inside the secrets file.
+4. `pnpm run dev` - To run the pusher. This step assumes already running signed API as specified in the `pusher.json`
+   configuration.
 
 ## Docker
 

--- a/packages/data-pusher/config/pusher.example.json
+++ b/packages/data-pusher/config/pusher.example.json
@@ -3,16 +3,16 @@
   "log": { "format": "plain", "level": "INFO" },
   "rateLimiting": { "maxDirectGatewayConcurrency": 25, "minDirectGatewayTime": 10 },
   "beacons": {
-    "0x45157f8e0c448d36b2780ac9fa74040c864be5866e2c4f8a621c54d9a6d1baa9": {
-      "airnode": "0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4",
+    "0xebba8507d616ed80766292d200a3598fdba656d9938cecc392765d4a284a69a4": {
+      "airnode": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
       "templateId": "0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd"
     },
-    "0xe1d3bc514126e305f90484f977be17996f9389613607ac88aee3c955919fda59": {
-      "airnode": "0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4",
+    "0x6f6acbdadaaf116c89faf0e8de1d0c7c2352b01cce7be0eb9deb126ceaefa6ba": {
+      "airnode": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
       "templateId": "0x086130c54864b2129f8ac6d8d7ab819fa8181bbe676e35047b1bca4c31d51c66"
     },
-    "0xc139000a53aa2863d802a263a840559398d2120f50f464474188a567a59ad452": {
-      "airnode": "0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4",
+    "0x7944f22b40cc691a003e35db4810b41543a83781d94f706b5c0b6980e0a06ed7": {
+      "airnode": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
       "templateId": "0x1d65c1f1e127a41cebd2339f823d0290322c63f3044380cbac105db8e522ebb9"
     }
   },
@@ -39,11 +39,11 @@
   "triggers": {
     "signedApiUpdates": [
       {
-        "signedApiName": "Nodary",
+        "signedApiName": "localhost",
         "beaconIds": [
-          "0x45157f8e0c448d36b2780ac9fa74040c864be5866e2c4f8a621c54d9a6d1baa9",
-          "0xe1d3bc514126e305f90484f977be17996f9389613607ac88aee3c955919fda59",
-          "0xc139000a53aa2863d802a263a840559398d2120f50f464474188a567a59ad452"
+          "0xebba8507d616ed80766292d200a3598fdba656d9938cecc392765d4a284a69a4",
+          "0x6f6acbdadaaf116c89faf0e8de1d0c7c2352b01cce7be0eb9deb126ceaefa6ba",
+          "0x7944f22b40cc691a003e35db4810b41543a83781d94f706b5c0b6980e0a06ed7"
         ],
         "fetchInterval": 5,
         "updateDelay": 30
@@ -52,13 +52,13 @@
   },
   "signedApis": [
     {
-      "name": "Nodary",
-      "url": "https://pool.nodary.io"
+      "name": "localhost",
+      "url": "http://localhost:8090"
     }
   ],
   "ois": [
     {
-      "oisFormat": "2.0.0",
+      "oisFormat": "2.1.0",
       "title": "Nodary",
       "version": "0.2.0",
       "apiSpecifications": {

--- a/packages/data-pusher/config/secrets.example.env
+++ b/packages/data-pusher/config/secrets.example.env
@@ -1,2 +1,6 @@
 # Secrets must NOT be quoted.
-WALLET_MNEMONIC=
+#
+# The mnemonic is randomly generated. !!! USE ONLY FOR DEVELOPMENT PURPOSES !!!.
+WALLET_MNEMONIC=diamond result history offer forest diagram crop armed stumble orchard stage glance
+# Get it from core development team, otherwise you can use some publicly available data provider API instead of Nodary.
+NODARY_API_KEY=

--- a/packages/data-pusher/package.json
+++ b/packages/data-pusher/package.json
@@ -30,6 +30,7 @@
     "@api3/promise-utils": "^0.4.0",
     "axios": "^1.5.0",
     "bottleneck": "^2.19.5",
+    "dotenv": "^16.3.1",
     "ethers": "^5.7.2",
     "express": "^4.18.2",
     "lodash": "^4.17.21",

--- a/packages/data-pusher/src/index.ts
+++ b/packages/data-pusher/src/index.ts
@@ -5,7 +5,9 @@
 // create a test script with/without the source map support, build the project and run the built script using node.
 import 'source-map-support/register';
 
-import * as path from 'path';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import dotenv from 'dotenv';
 import { loadConfig } from './validation/config';
 import { initiateFetchingBeaconData } from './fetch-beacon-data';
 import { initiateUpdatingSignedApi } from './update-signed-api';
@@ -13,7 +15,9 @@ import { initializeState } from './state';
 import { initializeWallet } from './wallets';
 
 export async function main() {
-  const config = await loadConfig(path.join(__dirname, '..', 'config', 'pusher.json'), process.env);
+  const configPath = join(__dirname, '..', 'config');
+  const secrets = dotenv.parse(readFileSync(join(configPath, 'secrets.env'), 'utf8'));
+  const config = await loadConfig(join(configPath, 'pusher.json'), secrets);
   initializeState(config);
 
   initializeWallet();

--- a/packages/data-pusher/src/make-request.ts
+++ b/packages/data-pusher/src/make-request.ts
@@ -285,5 +285,5 @@ export const postSignedApiData = async (group: SignedApiNameUpdateDelayGroup) =>
     );
     return;
   }
-  logger.info(`Signed datas (${goRes.data.count.toString()}) were pushed to pool.`, logOptions);
+  logger.info(`Pushed ${goRes.data.count.toString()} signed data updates to the pool.`, logOptions);
 };

--- a/packages/data-pusher/src/make-request.ts
+++ b/packages/data-pusher/src/make-request.ts
@@ -1,5 +1,5 @@
 import { isEmpty, isNil } from 'lodash';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { ethers } from 'ethers';
 import * as adapter from '@api3/airnode-adapter';
 import * as node from '@api3/airnode-node';
@@ -267,17 +267,23 @@ export const postSignedApiData = async (group: SignedApiNameUpdateDelayGroup) =>
     logger.debug('No batch payload found to post skipping.', logOptions);
     return;
   }
-  const goRes = await go(() =>
-    axios.post(provider.url, batchPayload, {
+  const goRes = await go<Promise<{ count: number }>, AxiosError>(async () => {
+    const axiosResponse = await axios.post(provider.url, batchPayload, {
       headers: {
         'Content-Type': 'application/json',
       },
-    })
-  );
+    });
+
+    return axiosResponse.data;
+  });
 
   if (!goRes.success) {
-    logger.warn(`Failed to post payload to update signed API. Err: ${goRes.error}`, logOptions);
+    logger.warn(
+      // See: https://axios-http.com/docs/handling_errors
+      `Failed to post payload to update signed API. Err: ${goRes.error}, axios response: ${goRes.error.response}`,
+      logOptions
+    );
     return;
   }
-  logger.info(`Signed datas (${goRes.data.data.count.toString()}) were pushed to pool.`, logOptions);
+  logger.info(`Signed datas (${goRes.data.count.toString()}) were pushed to pool.`, logOptions);
 };

--- a/packages/data-pusher/src/validation/config.ts
+++ b/packages/data-pusher/src/validation/config.ts
@@ -10,6 +10,6 @@ export const loadConfig = async (configPath: string, rawSecrets: Record<string, 
     return configSchema.parseAsync(interpolateSecrets(rawConfig, secrets));
   });
 
-  if (!goLoadConfig.success) throw new Error(`Unable to load configuration. Reason:\n${goLoadConfig.error}`);
+  if (!goLoadConfig.success) throw new Error(`Unable to load configuration.`, { cause: goLoadConfig.error });
   return goLoadConfig.data;
 };

--- a/packages/data-pusher/src/validation/schema.ts
+++ b/packages/data-pusher/src/validation/schema.ts
@@ -180,8 +180,10 @@ const validateTriggerReferences: SuperRefinement<{
     // Check only if beaconIds contains more than 1 beacon
     if (beaconIds.length > 1) {
       const operationPayloadPromises = beaconIds.map((beaconId) => {
+        // TODO: This can throw when there is no beacon - which is an unhandled error in this validation check.
         const template = templates[beacons[beaconId].templateId];
 
+        // TODO: This can throw when there is no template - which is an unhandled error in this validation check.
         const parameters = abi.decode(template.parameters);
         const endpoint = endpoints[template.endpointId];
 

--- a/packages/data-pusher/src/validation/utils.ts
+++ b/packages/data-pusher/src/validation/utils.ts
@@ -25,6 +25,7 @@ export const interpolateSecrets = (config: unknown, secrets: Record<string, stri
   );
 
   if (!goInterpolated.success) {
+    // TODO: This should use error cause
     throw new Error(`Error interpolating secrets. Make sure the secrets format is correct. ${goInterpolated.error}`);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       ethers:
         specifier: ^5.7.2
         version: 5.7.2


### PR DESCRIPTION
As a preparation for https://github.com/api3dao/signed-api/issues/21 I wanted to run the services together, but it took me some configuration effort so I decided to make a PR out of my work to save others a bit more time.

This PR:
- Changes the pusher example configuration to make it easy to run the services together.
- Documents how to run them together and basic dev instructions.
- Adds very basic logging and leaves some TODOs for later