### PR TITLE
Prune data

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -44,7 +44,8 @@ The API provides the following endpoints:
 
 - `POST /`: Insert a batch of signed data.
   - The batch is validated for consistency and data integrity errors. If there is any issue during this step, the whole
-    batch is rejected. Otherwise the batch is accepted.
+    batch is rejected. Otherwise the batch is accepted. Also, all data that is no longer needed is removed during this
+    step.
 - `GET /{endpoint-name}/{airnode}`: Retrieve signed data for the Airnode respecting the endpoint configuration.
   - Only returns the freshest signed data available for the given Airnode, respecting the configured endpoint delay.
 - `GET /`: Retrieve list of all available Airnode address.


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/35

## Rationale

I implemented it as a step during insert for performance and easy-ness to implement.  The pruning function takes a list of signed data for which it tries to remove no longer needed data. The pruning function is implemented as a separate function to reduce coupling between insertion and removal of the data.