### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,12 @@ The repo uses `pnpm` workspaces. To install the dependencies:
 ```sh
 pnpm install
 ```
+
+and to build the packages:
+
+```sh
+pnpm run build
+```
+
+Note, that everytime you make a change to a workspace that is used as a dependency of another, you need to rebuild the
+changed package (otherwise you might get weird JS/TS errors).

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,3 +1,11 @@
 # common
 
 Utilities commonly used by other packages.
+
+## Getting started
+
+Use:
+
+```sh
+pnpm run build
+```


### PR DESCRIPTION
Now, that there is `common` package as a dependency of other workspaces, you need to build the project before starting dev server.