### PR TITLE
Fix delayed queue premature data prune, add tests

### DIFF
--- a/packages/data-pusher/src/api-requests/signed-api.test.ts
+++ b/packages/data-pusher/src/api-requests/signed-api.test.ts
@@ -11,7 +11,7 @@ describe(postSignedApiData.name, () => {
     // Assumes the template responses are for unique template IDs (which is true in the test fixtures).
     state.templateValues = Object.fromEntries(
       nodarySignedTemplateResponses.map(([templateId, signedData]) => {
-        const dataQueue = new stateModule.DelayedSignedDataQueue();
+        const dataQueue = new stateModule.DelayedSignedDataQueue(0);
         dataQueue.put(signedData);
         return [templateId, dataQueue];
       })
@@ -29,7 +29,7 @@ describe(postSignedApiData.name, () => {
     // Assumes the template responses are for unique template IDs (which is true in the test fixtures).
     state.templateValues = Object.fromEntries(
       nodarySignedTemplateResponses.map(([templateId, signedData]) => {
-        const dataQueue = new stateModule.DelayedSignedDataQueue();
+        const dataQueue = new stateModule.DelayedSignedDataQueue(0);
         dataQueue.put(signedData);
         return [templateId, dataQueue];
       })
@@ -61,7 +61,7 @@ describe(postSignedApiData.name, () => {
     // Assumes the template responses are for unique template IDs (which is true in the test fixtures).
     state.templateValues = Object.fromEntries(
       nodarySignedTemplateResponses.map(([templateId, signedData]) => {
-        const dataQueue = new stateModule.DelayedSignedDataQueue();
+        const dataQueue = new stateModule.DelayedSignedDataQueue(0);
         dataQueue.put(signedData);
         return [templateId, dataQueue];
       })

--- a/packages/data-pusher/src/api-requests/signed-api.ts
+++ b/packages/data-pusher/src/api-requests/signed-api.ts
@@ -21,7 +21,10 @@ export const postSignedApiData = async (group: SignedApiNameUpdateDelayGroup) =>
 
   const airnode = ethers.Wallet.fromMnemonic(airnodeWalletMnemonic).address;
   const batchPayloadOrNull = templateIds.map((templateId): SignedApiPayload | null => {
-    const delayedSignedData = templateValues[templateId]!.get(updateDelay);
+    // Calculate the reference timestamp based on the current time and update delay.
+    const referenceTimestamp = Date.now() / 1000 - updateDelay;
+    const delayedSignedData = templateValues[templateId]!.get(referenceTimestamp);
+    templateValues[templateId]!.prune();
     if (isNil(delayedSignedData)) return null;
 
     return { airnode, templateId, beaconId: deriveBeaconId(airnode, templateId), ...delayedSignedData };

--- a/packages/data-pusher/src/state.test.ts
+++ b/packages/data-pusher/src/state.test.ts
@@ -1,0 +1,63 @@
+import { DelayedSignedDataQueue } from './state';
+import { nodarySignedTemplateResponses } from '../test/fixtures';
+
+describe(DelayedSignedDataQueue.name, () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('can put signed data', () => {
+    const queue = new DelayedSignedDataQueue(30);
+    const data = nodarySignedTemplateResponses[0]![1];
+
+    queue.put(data);
+
+    expect(queue.getAll()).toEqual([data]);
+  });
+
+  it('can get signed data with delay', () => {
+    const queue = new DelayedSignedDataQueue(30);
+    const data3 = nodarySignedTemplateResponses[0]![1];
+    const timestamp = parseInt(data3.timestamp);
+    const data2 = { ...data3, timestamp: (timestamp - 10).toString() };
+    const data1 = { ...data3, timestamp: (timestamp - 20).toString() };
+    queue.put(data1);
+    queue.put(data2);
+    queue.put(data3);
+
+    expect(queue.get(timestamp + 1)).toEqual(data3);
+    expect(queue.get(timestamp)).toEqual(data2);
+    expect(queue.get(timestamp - 5)).toEqual(data2);
+    expect(queue.get(timestamp - 15)).toEqual(data1);
+    expect(queue.get(timestamp - 30)).toEqual(undefined);
+  });
+
+  it('ensures that data is inserted by increasing timestamp', () => {
+    const queue = new DelayedSignedDataQueue(30);
+    const data3 = nodarySignedTemplateResponses[0]![1];
+    const timestamp = parseInt(data3.timestamp);
+    const data2 = { ...data3, timestamp: (timestamp - 10).toString() };
+    const data1 = { ...data3, timestamp: (timestamp - 20).toString() };
+    queue.put(data3);
+
+    expect(() => queue.put(data1)).toThrow('The signed data is too old');
+    expect(() => queue.put(data2)).toThrow('The signed data is too old');
+  });
+
+  it('can prune unused data', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+
+    const queue = new DelayedSignedDataQueue(30);
+    const data3 = nodarySignedTemplateResponses[0]![1];
+    const timestamp = parseInt(data3.timestamp);
+    const data2 = { ...data3, timestamp: (timestamp - 40).toString() };
+    const data1 = { ...data3, timestamp: (timestamp - 50).toString() };
+    queue.put(data1);
+    queue.put(data2);
+    queue.put(data3);
+
+    queue.prune();
+
+    expect(queue.getAll()).toEqual([data2, data3]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/43

While I was working on these tests I realized that the delayed queue should not purge the data during the `get` call. The implementation assumed that one queue will be called with just a single `updateTime`, but that may not be true because there can be multiple triggers (with different `updateTime`s).

The new implementation made `get` function pure and created a new `prune` function which can be called to remove the data that is no longer necessary. The queue is first initialized with a `maximumUpdateTime` which is the maximum update time across all triggers. 