### PR TITLE
Add unit test for validating triggers, improve mnemonic validation

### DIFF
--- a/packages/data-pusher/src/validation/schema.test.ts
+++ b/packages/data-pusher/src/validation/schema.test.ts
@@ -1,12 +1,29 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ZodError } from 'zod';
-import { configSchema, signedApisSchema } from './schema';
+import dotenv from 'dotenv';
+import { Config, configSchema, signedApisSchema } from './schema';
+import { interpolateSecrets } from './utils';
+import { config } from '../../test/fixtures';
 
 it('validates example config', async () => {
-  const config = JSON.parse(readFileSync(join(__dirname, '../../config/pusher.example.json'), 'utf8'));
+  const exampleConfig = JSON.parse(readFileSync(join(__dirname, '../../config/pusher.example.json'), 'utf8'));
 
-  await expect(configSchema.parseAsync(config)).resolves.toEqual(expect.any(Object));
+  // The mnemonic is not interpolated (and thus invalid).
+  await expect(configSchema.parseAsync(exampleConfig)).rejects.toEqual(
+    new ZodError([
+      {
+        code: 'custom',
+        message: 'Invalid mnemonic',
+        path: ['airnodeWalletMnemonic'],
+      },
+    ])
+  );
+
+  const exampleSecrets = dotenv.parse(readFileSync(join(__dirname, '../../config/secrets.example.env'), 'utf8'));
+  await expect(configSchema.parseAsync(interpolateSecrets(exampleConfig, exampleSecrets))).resolves.toEqual(
+    expect.any(Object)
+  );
 });
 
 it('ensures signed API names are unique', () => {
@@ -31,4 +48,25 @@ it('ensures signed API names are unique', () => {
       url: 'https://example.com',
     },
   ]);
+});
+
+it('validates trigger references', async () => {
+  const invalidConfig: Config = {
+    ...config,
+    ois: [
+      // By removing the pre-processing the triggers will end up with different operation effects.
+      { ...config.ois[0]!, endpoints: [{ ...config.ois[0]!.endpoints[0]!, preProcessingSpecifications: undefined }] },
+    ],
+  };
+
+  await expect(configSchema.parseAsync(invalidConfig)).rejects.toEqual(
+    new ZodError([
+      {
+        code: 'custom',
+        message:
+          'If beaconIds contains more than 1 beacon, the endpoint utilized by each beacons must have same operation effect',
+        path: ['triggers', 'signedApiUpdates', 0],
+      },
+    ])
+  );
 });

--- a/packages/data-pusher/src/validation/schema.ts
+++ b/packages/data-pusher/src/validation/schema.ts
@@ -249,7 +249,7 @@ export const apisCredentialsSchema = z.array(config.apiCredentialsSchema);
 
 export const configSchema = z
   .object({
-    airnodeWalletMnemonic: z.string(),
+    airnodeWalletMnemonic: z.string().refine((mnemonic) => ethers.utils.isValidMnemonic(mnemonic), 'Invalid mnemonic'),
     beaconSets: z.any(),
     chains: z.any(),
     gateways: z.any(),


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/55

I also noticed that there is a test verifying the example config, but without interpolating secrets. The mnemonic was specified only as `string` in the config, so the test passed. I've made the validation stronger.