### PR TITLE
Fix bug with data pruning

### DIFF
--- a/packages/pusher/src/state.test.ts
+++ b/packages/pusher/src/state.test.ts
@@ -61,4 +61,22 @@ describe(DelayedSignedDataQueue.name, () => {
 
     expect(queue.getAll()).toStrictEqual([data2, data3]);
   });
+
+  it('keeps data in the queue if none of the items exceed maxUpdateDelay', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+    const queue = new DelayedSignedDataQueue(30);
+    const data = nodarySignedTemplateResponses[0]![1];
+    const timestamp = Number.parseInt(data.timestamp, 10);
+    const oldData = [
+      { ...data, timestamp: (timestamp - 20).toString() },
+      { ...data, timestamp: (timestamp - 15).toString() },
+      { ...data, timestamp: (timestamp - 10).toString() },
+    ];
+    for (const item of oldData) queue.put(item);
+
+    queue.prune();
+
+    // All data points remain in the queue.
+    expect(queue.getAll()).toStrictEqual(oldData);
+  });
 });

--- a/packages/pusher/src/state.ts
+++ b/packages/pusher/src/state.ts
@@ -154,6 +154,7 @@ export class DelayedSignedDataQueue {
       this.isDelayedEnough(data, Date.now() / 1000 - this.maxUpdateDelay)
     );
 
+    if (index === -1) return;
     this.storage = this.storage.slice(index);
   }
 


### PR DESCRIPTION
I noticed a bug while testing unrelated changes,, where the delayed signed data queue would be pruned if none of the items were old enough.