### PR TITLE
Skip persisting signed data for data feed with existing timestamp

### DIFF
--- a/packages/api/src/cache.ts
+++ b/packages/api/src/cache.ts
@@ -1,7 +1,7 @@
 import type { SignedData } from './schema';
 
 type SignedDataCache = Record<
-  string, // Airnode ID.
+  string, // Airnode address.
   Record<
     string, // Template ID.
     SignedData[] // Signed data is ordered by timestamp (oldest first).

--- a/packages/api/src/in-memory-cache.ts
+++ b/packages/api/src/in-memory-cache.ts
@@ -10,26 +10,26 @@ export const ignoreTooFreshData = (signedDatas: SignedData[], ignoreAfterTimesta
 
 // The API is deliberately asynchronous to mimic a database call.
 // eslint-disable-next-line @typescript-eslint/require-await
-export const get = async (airnodeId: string, templateId: string, ignoreAfterTimestamp: number) => {
-  logger.debug('Getting signed data', { airnodeId, templateId, ignoreAfterTimestamp });
+export const get = async (airnodeAddress: string, templateId: string, ignoreAfterTimestamp: number) => {
+  logger.debug('Getting signed data', { airnodeAddress, templateId, ignoreAfterTimestamp });
 
   const signedDataCache = getCache();
-  if (!signedDataCache[airnodeId]) return null;
-  const signedDatas = signedDataCache[airnodeId]![templateId];
+  if (!signedDataCache[airnodeAddress]) return null;
+  const signedDatas = signedDataCache[airnodeAddress]![templateId];
   if (!signedDatas) return null;
 
   return last(ignoreTooFreshData(signedDatas, ignoreAfterTimestamp)) ?? null;
 };
 
 // The API is deliberately asynchronous to mimic a database call.
-export const getAll = async (airnodeId: string, ignoreAfterTimestamp: number) => {
-  logger.debug('Getting all signed data', { airnodeId, ignoreAfterTimestamp });
+export const getAll = async (airnodeAddress: string, ignoreAfterTimestamp: number) => {
+  logger.debug('Getting all signed data', { airnodeAddress, ignoreAfterTimestamp });
 
   const signedDataCache = getCache();
-  const signedDataByTemplateId = signedDataCache[airnodeId] ?? {};
+  const signedDataByTemplateId = signedDataCache[airnodeAddress] ?? {};
   const freshestSignedData: SignedData[] = [];
   for (const templateId of Object.keys(signedDataByTemplateId)) {
-    const freshest = await get(airnodeId, templateId, ignoreAfterTimestamp);
+    const freshest = await get(airnodeAddress, templateId, ignoreAfterTimestamp);
     if (freshest) freshestSignedData.push(freshest);
   }
 


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/90

## Background

In https://github.com/api3dao/signed-api/pull/34 we changed how signed API accepts data from pusher. In particular, it no longer checks [whether the signed data updates the timestamp](https://github.com/nodaryio/signed-api/blob/0f87e455cf24a20ea300893da5760bf0d739e133/src/handlers.ts#L159). This is by design because we may need the older data for delayed endpoints. This also improves throughput, because we don't need to reject full batch when a single signed data fails the check.

## Change

Because the pusher does not keep track of what data it sent to particular signed API it can attempt to send the same beacon data multiple times, increasing the storage requirements for signed API.

This change does not persists signed data for a data feed for which we already have a signed data value with the same timestamp. This assumes that the signed data with same timestamp is the same, but even if not - there is no way to pick "the correct one" so we can choose which one to skip.

The benefit of not keeping state in pusher is that it can re-push the data to the signed API in case it is redeployed (and loses all previously pushed data). The alternative to this would be to persist the timestamps of successfully pushed signed datas to avoid pushing them again.