### PR TITLE
Implement node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ FROM node:18-alpine as pusher
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=deployed-pusher /app/deployed-pusher .
-# Enabling source maps adds small runtime overhead, but improves debugging experience and the performance is worth it.
-ENTRYPOINT ["node", "--enable-source-maps", "dist/index.js"]
+ENTRYPOINT ["node", "dist/src/index.js"]
 
 # Create a separate stage for api package. We create a temporary stage for deployment and then copy the result into
 # the final stage. Only the production dependencies and package implementation is part of this last stage.
@@ -51,5 +50,4 @@ FROM node:18-alpine as api
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=deployed-api /app/deployed-api .
-# Enabling source maps adds small runtime overhead, but improves debugging experience and the performance is worth it.
-ENTRYPOINT ["node", "--enable-source-maps", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,7 @@
     "eslint:fix": "eslint . --ext .js,.ts --fix",
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,json}\"",
     "prettier:fix": "prettier --write \"./**/*.{js,ts,md,json}\"",
-    "start-prod": "node --enable-source-maps dist/index.js",
+    "start-prod": "node dist/index.js",
     "test": "jest",
     "tsc": "tsc --project ."
   },

--- a/packages/e2e/src/pusher/pusher.json
+++ b/packages/e2e/src/pusher/pusher.json
@@ -107,5 +107,8 @@
       ]
     }
   ],
-  "apiCredentials": []
+  "apiCredentials": [],
+  "nodeSettings": {
+    "nodeVersion": "0.1.0"
+  }
 }

--- a/packages/e2e/src/pusher/pusher.json
+++ b/packages/e2e/src/pusher/pusher.json
@@ -1,6 +1,4 @@
 {
-  "airnodeWalletMnemonic": "diamond result history offer forest diagram crop armed stumble orchard stage glance",
-  "rateLimiting": { "Mock API": { "maxConcurrency": 25, "minTime": 0 } },
   "templates": {
     "0xd1c9c79ccb6e24f77c14456b9b037ded9bfd0709468297e4e1e1bedbfe1bbf1a": {
       "endpointId": "0xa02c7e24d1d73f429927eedb78185a7d7d7c82d410acc3914cf6213aa29fea3f",
@@ -109,6 +107,8 @@
   ],
   "apiCredentials": [],
   "nodeSettings": {
-    "nodeVersion": "0.1.0"
+    "nodeVersion": "0.1.0",
+    "airnodeWalletMnemonic": "diamond result history offer forest diagram crop armed stumble orchard stage glance",
+    "rateLimiting": { "Mock API": { "maxConcurrency": 25, "minTime": 0 } }
   }
 }

--- a/packages/pusher/README.md
+++ b/packages/pusher/README.md
@@ -117,44 +117,6 @@ sensitive information inside secrets.
 
 You can also refer to the [example configuration](./config).
 
-#### `airnodeWalletMnemonic`
-
-Mnemonic for the airnode wallet used to sign the template responses. It is recommended to interpolate this value from
-secrets. For example:
-
-```jsonc
-// The mnemonic is interpolated from the "WALLET_MNEMONIC" secret.
-"airnodeWalletMnemonic": "${WALLET_MNEMONIC}"
-```
-
-#### `rateLimiting`
-
-Configuration for rate limiting OIS requests. Rate limiting can be configured for each OIS separately. For example:
-
-```jsonc
-// Defines no rate limiting.
-"rateLimiting": { },
-```
-
-or
-
-```jsonc
-// Defines rate limiting for OIS with title "Nodary"
-"rateLimiting": { "Nodary": { "maxConcurrency": 25, "minTime": 10 } },
-```
-
-##### `rateLimiting[<OIS_TITLE>]`
-
-The configuration for the OIS with title `<OIS_TITLE>`.
-
-###### `maxConcurrency`
-
-Maximum number of concurrent requests to the OIS.
-
-###### `minTime`
-
-Minimum time in milliseconds between two requests to the OIS.
-
 #### `templates`
 
 Configuration for the template requests. Each template request is defined by a `templateId` and a `template` object. For
@@ -344,6 +306,44 @@ Contains general deployment parameters of the pusher.
 ##### `nodeVersion`
 
 The version of the pusher. The version specified in the config must match the version of the pusher at deployment time.
+
+##### `airnodeWalletMnemonic`
+
+Mnemonic for the airnode wallet used to sign the template responses. It is recommended to interpolate this value from
+secrets. For example:
+
+```jsonc
+// The mnemonic is interpolated from the "WALLET_MNEMONIC" secret.
+"airnodeWalletMnemonic": "${WALLET_MNEMONIC}"
+```
+
+##### `rateLimiting`
+
+Configuration for rate limiting OIS requests. Rate limiting can be configured for each OIS separately. For example:
+
+```jsonc
+// Defines no rate limiting.
+"rateLimiting": { },
+```
+
+or
+
+```jsonc
+// Defines rate limiting for OIS with title "Nodary"
+"rateLimiting": { "Nodary": { "maxConcurrency": 25, "minTime": 10 } },
+```
+
+###### `rateLimiting[<OIS_TITLE>]`
+
+The configuration for the OIS with title `<OIS_TITLE>`.
+
+`maxConcurrency`
+
+Maximum number of concurrent requests to the OIS.
+
+`minTime`
+
+Minimum time in milliseconds between two requests to the OIS.
 
 ## Deployment
 

--- a/packages/pusher/README.md
+++ b/packages/pusher/README.md
@@ -337,6 +337,14 @@ Refer to the [OIS documentation](https://dapi-docs.api3.org/reference/ois/latest
 Refer to Airnode's
 [API credentials](https://dapi-docs.api3.org/reference/airnode/latest/deployment-files/config-json.html#apicredentials).
 
+#### `nodeSettings`
+
+Contains general deployment parameters of the pusher.
+
+##### `nodeVersion`
+
+The version of the pusher. The version specified in the config must match the version of the pusher at deployment time.
+
 ## Deployment
 
 TODO: Write example how to deploy on AWS

--- a/packages/pusher/config/pusher.example.json
+++ b/packages/pusher/config/pusher.example.json
@@ -1,6 +1,4 @@
 {
-  "airnodeWalletMnemonic": "${WALLET_MNEMONIC}",
-  "rateLimiting": { "Nodary": { "maxConcurrency": 25, "minTime": 10 } },
   "templates": {
     "0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd": {
       "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
@@ -95,6 +93,8 @@
     }
   ],
   "nodeSettings": {
-    "nodeVersion": "0.1.0"
+    "nodeVersion": "0.1.0",
+    "airnodeWalletMnemonic": "${WALLET_MNEMONIC}",
+    "rateLimiting": { "Nodary": { "maxConcurrency": 25, "minTime": 10 } }
   }
 }

--- a/packages/pusher/config/pusher.example.json
+++ b/packages/pusher/config/pusher.example.json
@@ -93,5 +93,8 @@
       "securitySchemeName": "NodarySecurityScheme1ApiKey",
       "securitySchemeValue": "${NODARY_API_KEY}"
     }
-  ]
+  ],
+  "nodeSettings": {
+    "nodeVersion": "0.1.0"
+  }
 }

--- a/packages/pusher/package.json
+++ b/packages/pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusher",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "engines": {
     "node": "^18.14.0",
     "pnpm": "^8.8.0"
@@ -15,7 +15,7 @@
     "eslint:fix": "eslint . --ext .js,.ts --fix",
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,yml,json}\"",
     "prettier:fix": "prettier --write \"./**/*.{js,ts,md,yml,json}\"",
-    "start-prod": "node --enable-source-maps dist/index.js",
+    "start-prod": "node dist/src/index.js",
     "test": "jest",
     "tsc": "tsc --project ."
   },

--- a/packages/pusher/src/state.ts
+++ b/packages/pusher/src/state.ts
@@ -24,14 +24,17 @@ export const initializeState = (config: Config) => {
 };
 
 export const buildApiLimiters = (config: Config) => {
-  if (!config.ois) {
+  const { ois, nodeSettings, templates } = config;
+  const { rateLimiting } = nodeSettings;
+
+  if (!ois) {
     return {};
   }
 
   const oisLimiters = Object.fromEntries(
-    config.ois.map((ois) => {
-      if (config.rateLimiting[ois.title]) {
-        const { minTime, maxConcurrency } = config.rateLimiting[ois.title]!;
+    ois.map((ois) => {
+      if (rateLimiting[ois.title]) {
+        const { minTime, maxConcurrency } = rateLimiting[ois.title]!;
 
         return [
           ois.title,
@@ -54,14 +57,12 @@ export const buildApiLimiters = (config: Config) => {
     })
   );
   const endpointTitles = Object.fromEntries(
-    config.ois.flatMap((ois) =>
-      ois.endpoints.map((endpoint) => [deriveEndpointId(ois.title, endpoint.name), ois.title])
-    )
+    ois.flatMap((ois) => ois.endpoints.map((endpoint) => [deriveEndpointId(ois.title, endpoint.name), ois.title]))
   );
 
   // Make use of the reference/pointer nature of objects
   const apiLimiters = Object.fromEntries(
-    Object.entries(config.templates).map(([templateId, template]) => {
+    Object.entries(templates).map(([templateId, template]) => {
       const title = endpointTitles[template.endpointId]!;
       return [templateId, oisLimiters[title]];
     })
@@ -84,7 +85,7 @@ export const getInitialState = (config: Config): State => {
     config,
     templateValues: buildTemplateStorages(config),
     apiLimiters: buildApiLimiters(config),
-    airnodeWallet: ethers.Wallet.fromMnemonic(config.airnodeWalletMnemonic),
+    airnodeWallet: ethers.Wallet.fromMnemonic(config.nodeSettings.airnodeWalletMnemonic),
   };
 };
 

--- a/packages/pusher/src/validation/config.ts
+++ b/packages/pusher/src/validation/config.ts
@@ -1,5 +1,6 @@
 import fs, { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { cwd } from 'node:process';
 
 import { go } from '@api3/promise-utils';
 import dotenv from 'dotenv';
@@ -8,7 +9,11 @@ import { configSchema } from './schema';
 import { interpolateSecrets, parseSecrets } from './utils';
 
 export const loadConfig = async () => {
-  const configPath = join(__dirname, '../../config');
+  // When pusher is built the "/dist" file contains "src" folder and "package.json" and the config is expected to be
+  // located next to the "/dist" folder. When run in development, the config is expected to be located next to the "src"
+  // folder (one less import level). We resolve the config by CWD as a workaround. Since the pusher is dockerized, this
+  // is hidden from the user.
+  const configPath = join(cwd(), './config');
   const rawSecrets = dotenv.parse(readFileSync(join(configPath, 'secrets.env'), 'utf8'));
 
   const goLoadConfig = await go(async () => {

--- a/packages/pusher/src/validation/schema.test.ts
+++ b/packages/pusher/src/validation/schema.test.ts
@@ -18,7 +18,7 @@ test('validates example config', async () => {
       {
         code: 'custom',
         message: 'Invalid mnemonic',
-        path: ['airnodeWalletMnemonic'],
+        path: ['nodeSettings', 'airnodeWalletMnemonic'],
       },
     ])
   );

--- a/packages/pusher/src/validation/schema.test.ts
+++ b/packages/pusher/src/validation/schema.test.ts
@@ -29,6 +29,26 @@ test('validates example config', async () => {
   );
 });
 
+test('ensures nodeVersion matches pusher version', async () => {
+  const invalidConfig: Config = {
+    ...config,
+    nodeSettings: {
+      ...config.nodeSettings,
+      nodeVersion: '0.0.1',
+    },
+  };
+
+  await expect(configSchema.parseAsync(invalidConfig)).rejects.toStrictEqual(
+    new ZodError([
+      {
+        code: 'custom',
+        message: 'Invalid node version',
+        path: ['nodeSettings', 'nodeVersion'],
+      },
+    ])
+  );
+});
+
 test('ensures signed API names are unique', () => {
   expect(() =>
     signedApisSchema.parse([

--- a/packages/pusher/src/validation/schema.ts
+++ b/packages/pusher/src/validation/schema.ts
@@ -13,6 +13,8 @@ import { ethers } from 'ethers';
 import { isNil, uniqWith, isEqual } from 'lodash';
 import { z, type SuperRefinement } from 'zod';
 
+import packageJson from '../../package.json';
+
 export const limiterConfig = z.object({ minTime: z.number(), maxConcurrency: z.number() });
 
 export const parameterSchema = z
@@ -242,6 +244,10 @@ export const oisesSchema = z.array(oisSchema);
 
 export const apisCredentialsSchema = z.array(config.apiCredentialsSchema);
 
+export const nodeSettingsSchema = z.object({
+  nodeVersion: z.string().refine((version) => version === packageJson.version, 'Invalid node version'),
+});
+
 export const configSchema = z
   .object({
     airnodeWalletMnemonic: z.string().refine((mnemonic) => ethers.utils.isValidMnemonic(mnemonic), 'Invalid mnemonic'),
@@ -250,6 +256,7 @@ export const configSchema = z
     chains: z.any(),
     endpoints: endpointsSchema,
     gateways: z.any(),
+    nodeSettings: nodeSettingsSchema,
     ois: oisesSchema,
     rateLimiting: rateLimitingSchema,
     signedApis: signedApisSchema,

--- a/packages/pusher/test/fixtures.ts
+++ b/packages/pusher/test/fixtures.ts
@@ -1,5 +1,6 @@
 import type { AxiosResponse } from 'axios';
 
+import packageJson from '../package.json';
 import type { SignedResponse, TemplateResponse } from '../src/sign-template-data';
 import type { Config } from '../src/validation/schema';
 
@@ -99,6 +100,9 @@ export const config: Config = {
       securitySchemeValue: 'invalid-api-key',
     },
   ],
+  nodeSettings: {
+    nodeVersion: packageJson.version,
+  },
 };
 
 export const nodaryTemplateRequestResponseData = {

--- a/packages/pusher/test/fixtures.ts
+++ b/packages/pusher/test/fixtures.ts
@@ -5,8 +5,6 @@ import type { SignedResponse, TemplateResponse } from '../src/sign-template-data
 import type { Config } from '../src/validation/schema';
 
 export const config: Config = {
-  airnodeWalletMnemonic: 'diamond result history offer forest diagram crop armed stumble orchard stage glance',
-  rateLimiting: { Nodary: { maxConcurrency: 25, minTime: 10 } },
   templates: {
     '0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd': {
       endpointId: '0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc',
@@ -102,6 +100,8 @@ export const config: Config = {
   ],
   nodeSettings: {
     nodeVersion: packageJson.version,
+    airnodeWalletMnemonic: 'diamond result history offer forest diagram crop armed stumble orchard stage glance',
+    rateLimiting: { Nodary: { maxConcurrency: 25, minTime: 10 } },
   },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
+    "resolveJsonModule": true,
 
     // Disabled because they are covered by Eslint rules
     "noUnusedLocals": false,


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/82

## Rationale

Added `nodeSettings.nodeVersion` similar to the Airnode. I am not entirely happy with the naming, but sticked to the on used in Airnode. Also, I put the node version inside `nodeSettings` in anticipation for other fields (e.g. stage).

I also noticed that I didn't completely remove source maps in https://github.com/api3dao/signed-api/pull/64 so I removed the (no longer necessary) `--enable-source-maps` flag.