### PR TITLE
Implement Airnode whitelisting

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -134,6 +134,25 @@ The port on which the API is served.
 
 The maximum age of the cache header in seconds.
 
+#### `allowedAirnodes`
+
+The list of allowed Airnode addresses. If the list is empty, no Airnode is allowed. To whitelist all Airnodes, set the
+value to `"all"` instead of an array.
+
+Example:
+
+```jsonc
+// Allows pushing signed data from any Airnode.
+"allowedAirnodes": "all"
+```
+
+or
+
+```jsonc
+// Allows pushing signed data only from the specific Airnode.
+"allowedAirnodes": ["0xB47E3D8734780430ee6EfeF3c5407090601Dcd15"]
+```
+
 ## API
 
 The API provides the following endpoints:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -137,13 +137,13 @@ The maximum age of the cache header in seconds.
 #### `allowedAirnodes`
 
 The list of allowed Airnode addresses. If the list is empty, no Airnode is allowed. To whitelist all Airnodes, set the
-value to `"all"` instead of an array.
+value to `"*"` instead of an array.
 
 Example:
 
 ```jsonc
 // Allows pushing signed data from any Airnode.
-"allowedAirnodes": "all"
+"allowedAirnodes": "*"
 ```
 
 or

--- a/packages/api/config/signed-api.example.json
+++ b/packages/api/config/signed-api.example.json
@@ -9,6 +9,7 @@
       "delaySeconds": 15
     }
   ],
+  "allowedAirnodes": ["0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"],
   "maxBatchSize": 10,
   "port": 8090,
   "cache": {

--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -25,12 +25,20 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
     );
   }
 
+  // Ensure that the batch of signed that comes from a whitelisted Airnode.
+  const { maxBatchSize, endpoints, allowedAirnodes } = getConfig();
+  if (
+    allowedAirnodes !== 'all' &&
+    !goValidateSchema.data.every((signedData) => allowedAirnodes.includes(signedData.airnode))
+  ) {
+    return generateErrorResponse(403, 'Unauthorized Airnode address');
+  }
+
   // Ensure there is at least one signed data to push
   const batchSignedData = goValidateSchema.data;
   if (isEmpty(batchSignedData)) return generateErrorResponse(400, 'No signed data to push');
 
   // Check whether the size of batch exceeds a maximum batch size
-  const { maxBatchSize, endpoints } = getConfig();
   if (size(batchSignedData) > maxBatchSize) {
     return generateErrorResponse(400, `Maximum batch size (${maxBatchSize}) exceeded`);
   }
@@ -120,6 +128,11 @@ export const getData = async (airnodeAddress: string, delaySeconds: number): Pro
     return generateErrorResponse(400, 'Invalid request, airnode address must be an EVM address');
   }
 
+  const { allowedAirnodes } = getConfig();
+  if (allowedAirnodes !== 'all' && !allowedAirnodes.includes(airnodeAddress)) {
+    return generateErrorResponse(403, 'Unauthorized Airnode address');
+  }
+
   const ignoreAfterTimestamp = Math.floor(Date.now() / 1000 - delaySeconds);
   const goReadDb = await go(async () => getAll(airnodeAddress, ignoreAfterTimestamp));
   if (!goReadDb.success) {
@@ -137,8 +150,9 @@ export const getData = async (airnodeAddress: string, delaySeconds: number): Pro
   };
 };
 
-// Returns all airnode addresses for which there is data. Note, that the delayed endpoint may not be allowed to show
-// it.
+// Returns all airnode addresses for which there is data. Note, that the delayed endpoint may not be allowed to show it.
+// We do not return the allowed Airnode addresses in the configuration, because the value can be set to "all" and we
+// would have to scan the database anyway.
 export const listAirnodeAddresses = async (): Promise<ApiResponse> => {
   const goAirnodeAddresses = await go(async () => getAllAirnodeAddresses());
   if (!goAirnodeAddresses.success) {

--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -28,7 +28,7 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
   // Ensure that the batch of signed that comes from a whitelisted Airnode.
   const { maxBatchSize, endpoints, allowedAirnodes } = getConfig();
   if (
-    allowedAirnodes !== 'all' &&
+    allowedAirnodes !== '*' &&
     !goValidateSchema.data.every((signedData) => allowedAirnodes.includes(signedData.airnode))
   ) {
     return generateErrorResponse(403, 'Unauthorized Airnode address');
@@ -129,7 +129,7 @@ export const getData = async (airnodeAddress: string, delaySeconds: number): Pro
   }
 
   const { allowedAirnodes } = getConfig();
-  if (allowedAirnodes !== 'all' && !allowedAirnodes.includes(airnodeAddress)) {
+  if (allowedAirnodes !== '*' && !allowedAirnodes.includes(airnodeAddress)) {
     return generateErrorResponse(403, 'Unauthorized Airnode address');
   }
 
@@ -151,7 +151,7 @@ export const getData = async (airnodeAddress: string, delaySeconds: number): Pro
 };
 
 // Returns all airnode addresses for which there is data. Note, that the delayed endpoint may not be allowed to show it.
-// We do not return the allowed Airnode addresses in the configuration, because the value can be set to "all" and we
+// We do not return the allowed Airnode addresses in the configuration, because the value can be set to "*" and we
 // would have to scan the database anyway.
 export const listAirnodeAddresses = async (): Promise<ApiResponse> => {
   const goAirnodeAddresses = await go(async () => getAllAirnodeAddresses());

--- a/packages/api/src/schema.test.ts
+++ b/packages/api/src/schema.test.ts
@@ -124,8 +124,8 @@ describe('env config schema', () => {
 
 describe('allowed Airnodes schema', () => {
   it('accepts valid configuration', () => {
-    const allValid = allowedAirnodesSchema.parse('all');
-    expect(allValid).toBe('all');
+    const allValid = allowedAirnodesSchema.parse('*');
+    expect(allValid).toBe('*');
 
     expect(
       allowedAirnodesSchema.parse([

--- a/packages/api/src/schema.test.ts
+++ b/packages/api/src/schema.test.ts
@@ -4,7 +4,14 @@ import { join } from 'node:path';
 import dotenv from 'dotenv';
 import { ZodError } from 'zod';
 
-import { configSchema, endpointSchema, endpointsSchema, envBooleanSchema, envConfigSchema } from './schema';
+import {
+  allowedAirnodesSchema,
+  configSchema,
+  endpointSchema,
+  endpointsSchema,
+  envBooleanSchema,
+  envConfigSchema,
+} from './schema';
 
 describe('endpointSchema', () => {
   it('validates urlPath', () => {
@@ -112,5 +119,19 @@ describe('env config schema', () => {
         },
       ])
     );
+  });
+});
+
+describe('allowed Airnodes schema', () => {
+  it('accepts valid configuration', () => {
+    const allValid = allowedAirnodesSchema.parse('all');
+    expect(allValid).toBe('all');
+
+    expect(
+      allowedAirnodesSchema.parse([
+        '0xB47E3D8734780430ee6EfeF3c5407090601Dcd15',
+        '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11',
+      ])
+    ).toStrictEqual(['0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11']);
   });
 });

--- a/packages/api/src/schema.test.ts
+++ b/packages/api/src/schema.test.ts
@@ -134,4 +134,20 @@ describe('allowed Airnodes schema', () => {
       ])
     ).toStrictEqual(['0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11']);
   });
+
+  it('disallows empty list', () => {
+    expect(() => allowedAirnodesSchema.parse([])).toThrow(
+      new ZodError([
+        {
+          code: 'too_small',
+          minimum: 1,
+          type: 'array',
+          inclusive: true,
+          exact: false,
+          message: 'Array must contain at least 1 element(s)',
+          path: [],
+        },
+      ])
+    );
+  });
 });

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -2,6 +2,10 @@ import { type LogFormat, logFormatOptions, logLevelOptions, type LogLevel } from
 import { uniqBy } from 'lodash';
 import { z } from 'zod';
 
+export const evmAddressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
+
+export const evmIdSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM hash');
+
 export const endpointSchema = z
   .object({
     urlPath: z
@@ -20,6 +24,8 @@ export const endpointsSchema = z
     'Each "urlPath" of an endpoint must be unique'
   );
 
+export const allowedAirnodesSchema = z.union([z.literal('all'), z.array(evmAddressSchema)]);
+
 export const configSchema = z
   .object({
     endpoints: endpointsSchema,
@@ -28,14 +34,11 @@ export const configSchema = z
     cache: z.object({
       maxAgeSeconds: z.number().nonnegative().int(),
     }),
+    allowedAirnodes: allowedAirnodesSchema,
   })
   .strict();
 
 export type Config = z.infer<typeof configSchema>;
-
-export const evmAddressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
-
-export const evmIdSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM hash');
 
 export const signedDataSchema = z.object({
   airnode: evmAddressSchema,

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const evmAddressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
 
-export const evmIdSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM hash');
+export const evmIdSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM ID');
 
 export const endpointSchema = z
   .object({

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -24,7 +24,7 @@ export const endpointsSchema = z
     'Each "urlPath" of an endpoint must be unique'
   );
 
-export const allowedAirnodesSchema = z.union([z.literal('all'), z.array(evmAddressSchema)]);
+export const allowedAirnodesSchema = z.union([z.literal('all'), z.array(evmAddressSchema).nonempty()]);
 
 export const configSchema = z
   .object({

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -24,7 +24,7 @@ export const endpointsSchema = z
     'Each "urlPath" of an endpoint must be unique'
   );
 
-export const allowedAirnodesSchema = z.union([z.literal('all'), z.array(evmAddressSchema).nonempty()]);
+export const allowedAirnodesSchema = z.union([z.literal('*'), z.array(evmAddressSchema).nonempty()]);
 
 export const configSchema = z
   .object({

--- a/packages/api/test/fixtures.ts
+++ b/packages/api/test/fixtures.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const getMockedConfig = () => {
+  const config = JSON.parse(readFileSync(join(__dirname, '../config/signed-api.example.json'), 'utf8'));
+  config.allowedAirnodes = 'all';
+
+  return config;
+};

--- a/packages/api/test/fixtures.ts
+++ b/packages/api/test/fixtures.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 export const getMockedConfig = () => {
   const config = JSON.parse(readFileSync(join(__dirname, '../config/signed-api.example.json'), 'utf8'));
-  config.allowedAirnodes = 'all';
+  config.allowedAirnodes = '*';
 
   return config;
 };

--- a/packages/e2e/src/signed-api/signed-api.json
+++ b/packages/e2e/src/signed-api/signed-api.json
@@ -13,5 +13,6 @@
   "port": 8090,
   "cache": {
     "maxAgeSeconds": 0
-  }
+  },
+  "allowedAirnodes": ["0xbF3137b0a7574563a23a8fC8badC6537F98197CC"]
 }


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/98

## Rationale

Adding the configuration option for whitelisting addresses is simple, but there is a special case - how to whitelist all? We can have a special meaning for empty array, [similarly how it's done in Airnode](https://docs.api3.org/reference/airnode/latest/concepts/authorizers.html#special-case-all-authorizers-values-are-empty-arrays) but I think it would be better for this to be explicit and set it to `"all"` instead (string literal instead of an array). Alternatively, we can drop the "whitelist all" use case.

The naming is `"allowedAirnodes"`, because it's about Airnode addresses, but the service is not Airnode but Pusher. I don't mind this, because [Pusher and Airnode are related](https://api3workspace.slack.com/archives/C05S589E7B4/p1695824428354099?thread_ts=1695809464.082009&cid=C05S589E7B4).

The `"allowedAirnodes"` configuration is used for both inserting/querying the data. The "list airnode addresses" endpoint is unchanged, because when all Airnodes are allowed we would need to scan the data storage anyway.