### PR TITLE
Improve heartbeat log

### DIFF
--- a/packages/pusher/src/heartbeat/heartbeat.test.ts
+++ b/packages/pusher/src/heartbeat/heartbeat.test.ts
@@ -3,13 +3,13 @@ import { join } from 'node:path';
 
 import * as promiseUtilsModule from '@api3/promise-utils';
 
-import { config, parseHeartbeatLog } from '../../test/fixtures';
+import { config, verifyHeartbeatLog } from '../../test/fixtures';
 import * as stateModule from '../state';
 import * as configModule from '../validation/config';
 
 import { heartbeatLogger } from './logger';
 
-import { initiateHeartbeat, logHeartbeat, createHash } from '.';
+import { initiateHeartbeat, logHeartbeat, type HeartbeatPayload, stringifyUnsignedHeartbeatPayload } from '.';
 
 // eslint-disable-next-line jest/no-hooks
 beforeEach(() => {
@@ -21,17 +21,17 @@ afterEach(() => {
 });
 
 describe(logHeartbeat.name, () => {
-  const expectedLogMessage = [
-    '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
-    'test',
-    '0.1.0',
-    '1674172803',
-    '1674172800',
-    '0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286',
-    '0x14f123ec1006bace8f8971cd8c94eb022b9bb0e1364e88ae4e8562a5f02de43e35dd4ecdefc976595eba5fec3d04222a0249e876453599b27847e85e14ff77601b',
-  ].join(' - ');
-
   it('sends the correct heartbeat log', async () => {
+    const expectedLogMessage: HeartbeatPayload = {
+      airnode: '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
+      stage: 'test',
+      nodeVersion: '0.1.0',
+      currentTimestamp: '1674172803',
+      deploymentTimestamp: '1674172800',
+      configHash: '0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286',
+      signature:
+        '0x24467037db96b652286c30c39ee9611faff07e1c17916f5c154ea7a27dfbc32f308969bdadf586bdaee0951b84819633e126a4fc72e3aa2e98a6eda95ce640081b',
+    };
     const rawConfig = JSON.parse(readFileSync(join(__dirname, '../../config/pusher.example.json'), 'utf8'));
     jest.spyOn(configModule, 'loadRawConfig').mockReturnValue(rawConfig);
     const state = stateModule.getInitialState(config);
@@ -41,27 +41,51 @@ describe(logHeartbeat.name, () => {
 
     await logHeartbeat();
 
-    expect(heartbeatLogger.info).toHaveBeenCalledWith(expectedLogMessage);
+    expect(heartbeatLogger.info).toHaveBeenCalledWith('Sending heartbeat log', expectedLogMessage);
   });
+});
 
-  it('the heartbeat log can be parsed', () => {
-    const rawConfig = JSON.parse(readFileSync(join(__dirname, '../../config/pusher.example.json'), 'utf8'));
-    jest.spyOn(configModule, 'loadRawConfig').mockReturnValue(rawConfig);
-    const expectedHeartbeatPayload = {
-      airnodeAddress: '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
-      stage: 'test',
-      nodeVersion: '0.1.0',
-      heartbeatTimestamp: '1674172803',
-      deploymentTimestamp: '1674172800',
-      configHash: '0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286',
-      signature:
-        '0x14f123ec1006bace8f8971cd8c94eb022b9bb0e1364e88ae4e8562a5f02de43e35dd4ecdefc976595eba5fec3d04222a0249e876453599b27847e85e14ff77601b',
+describe(verifyHeartbeatLog.name, () => {
+  it('heartbeat payload can be parsed from JSON log', () => {
+    const jsonLog = {
+      context: {
+        airnode: '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
+        configHash: '0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286',
+        currentTimestamp: '1674172803',
+        deploymentTimestamp: '1674172800',
+        nodeVersion: '0.1.0',
+        signature:
+          '0x24467037db96b652286c30c39ee9611faff07e1c17916f5c154ea7a27dfbc32f308969bdadf586bdaee0951b84819633e126a4fc72e3aa2e98a6eda95ce640081b',
+        stage: 'test',
+      },
+      level: 'info',
+      message: 'Sending heartbeat log',
+      ms: '+0ms',
+      timestamp: '2023-01-20T00:00:03.000Z',
     };
+    // The config hash is taken from config with all spaces removed.
+    const rawConfig = JSON.stringify(
+      JSON.parse(readFileSync(join(__dirname, '../../config/pusher.example.json'), 'utf8'))
+    );
 
-    const heartbeatPayload = parseHeartbeatLog(expectedLogMessage);
+    expect(() => verifyHeartbeatLog(jsonLog.context, rawConfig)).not.toThrow();
+  });
+});
 
-    expect(heartbeatPayload).toStrictEqual(expectedHeartbeatPayload);
-    expect(heartbeatPayload.configHash).toBe(createHash(JSON.stringify(rawConfig)));
+describe(stringifyUnsignedHeartbeatPayload.name, () => {
+  it('sorts the keys alphabetically', () => {
+    expect(
+      stringifyUnsignedHeartbeatPayload({
+        airnode: '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
+        stage: 'test',
+        nodeVersion: '0.1.0',
+        currentTimestamp: '1674172803',
+        deploymentTimestamp: '1674172800',
+        configHash: '0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286',
+      })
+    ).toBe(
+      '{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","configHash":"0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286","currentTimestamp":"1674172803","deploymentTimestamp":"1674172800","nodeVersion":"0.1.0","stage":"test"}'
+    );
   });
 });
 

--- a/packages/pusher/src/state.ts
+++ b/packages/pusher/src/state.ts
@@ -15,7 +15,7 @@ export interface State {
   // We persist the derived Airnode wallet in memory as a performance optimization.
   airnodeWallet: ethers.Wallet;
   // The timestamp of when the service was initialized. This can be treated as a "deployment" timestamp.
-  deploymentTimestamp: number;
+  deploymentTimestamp: string;
 }
 
 let state: State;
@@ -88,7 +88,7 @@ export const getInitialState = (config: Config): State => {
     templateValues: buildTemplateStorages(config),
     apiLimiters: buildApiLimiters(config),
     airnodeWallet: ethers.Wallet.fromMnemonic(config.nodeSettings.airnodeWalletMnemonic),
-    deploymentTimestamp: Math.floor(Date.now() / 1000),
+    deploymentTimestamp: Math.floor(Date.now() / 1000).toString(),
   };
 };
 


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/107

## Rationale

Rework the log message into a more machine-parseable format. Note, that I've slightly updated how the signing works (we now sign the heartbeat payload object instead of array).

The JSON log message would be:
```json
{"context":{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","configHash":"0x126e768ba244efdb790d63a76821047e163dfc502ace09b2546a93075594c286","currentTimestamp":"1674172803","deploymentTimestamp":"1674172800","nodeVersion":"0.1.0","signature":"0x180b77067b4c319f97fd9b0ff5d6dcbaa02647d0a41497a2256a3b8a42d5f5b16301d1b10fd899c5cba40ea165b4a8fcde7c6e486b21141f5289c0d288c2436f1c","stage":"test"},"level":"info","message":"Sending heartbeat log","ms":"+0ms","timestamp":"2023-01-20T00:00:03.000Z"}
```

You can identify the heartbeat log by the `message` field. The payload will be inside `context` field.

_(You can verify this by changing `jest.spyOn(heartbeatLogger, 'info').mockImplementation();` to `jest.spyOn(heartbeatLogger, 'info')` and running `LOG_FORMAT=json pnpm run test heart` in the heartbeat test)_