### PR TITLE
Update SignedApiResponse schema

### DIFF
--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -1,6 +1,8 @@
 import { go, goSync } from '@api3/promise-utils';
 import { isEmpty, isNil, omit, size } from 'lodash';
 
+import type { SignedApiResponse } from '../../pusher/src/validation/schema';
+
 import { getConfig } from './config';
 import { CACHE_HEADERS, COMMON_HEADERS } from './constants';
 import { deriveBeaconId, recoverSignerAddress } from './evm';
@@ -110,10 +112,15 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
     return generateErrorResponse(500, 'Unable to remove outdated cache data', goPruneCache.error.message);
   }
 
+  const response: SignedApiResponse = {
+    count: newSignedData.length,
+    skipped: batchSignedData.length - newSignedData.length,
+  };
+
   return {
     statusCode: 201,
     headers: COMMON_HEADERS,
-    body: JSON.stringify({ count: newSignedData.length, skipped: batchSignedData.length - newSignedData.length }),
+    body: JSON.stringify(response),
   };
 };
 

--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -1,8 +1,6 @@
 import { go, goSync } from '@api3/promise-utils';
 import { isEmpty, isNil, omit, size } from 'lodash';
 
-import type { SignedApiResponse } from '../../pusher/src/validation/schema';
-
 import { getConfig } from './config';
 import { CACHE_HEADERS, COMMON_HEADERS } from './constants';
 import { deriveBeaconId, recoverSignerAddress } from './evm';
@@ -112,15 +110,13 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
     return generateErrorResponse(500, 'Unable to remove outdated cache data', goPruneCache.error.message);
   }
 
-  const response: SignedApiResponse = {
-    count: newSignedData.length,
-    skipped: batchSignedData.length - newSignedData.length,
-  };
-
   return {
     statusCode: 201,
     headers: COMMON_HEADERS,
-    body: JSON.stringify(response),
+    body: JSON.stringify({
+      count: newSignedData.length,
+      skipped: batchSignedData.length - newSignedData.length,
+    }),
   };
 };
 

--- a/packages/pusher/src/validation/schema.ts
+++ b/packages/pusher/src/validation/schema.ts
@@ -285,6 +285,7 @@ export const secretsSchema = z.record(z.string());
 
 export const signedApiResponseSchema = z.strictObject({
   count: z.number(),
+  skipped: z.number(),
 });
 
 export type SignedApiResponse = z.infer<typeof signedApiResponseSchema>;

--- a/packages/pusher/test/fixtures.ts
+++ b/packages/pusher/test/fixtures.ts
@@ -184,7 +184,7 @@ export const signedApiResponse: Partial<AxiosResponse> = {
     'access-control-allow-origin': '*',
     'access-control-allow-methods': '*',
   },
-  data: { count: 3 },
+  data: { count: 3, skipped: 1 },
 };
 
 export const verifyHeartbeatLog = (heartbeatPayload: HeartbeatPayload, rawConfig: string) => {


### PR DESCRIPTION
This PR updates the response schema and associated test resources.

~Maybe having the type on the output payload dictionary is too verbose 🤷, happy to revert of course, but this way it will be obvious in future if there's a mismatch.~

Closes #115 
