### PR TITLE
Add spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A monorepo for managing signed data. Consists of:
 - [pusher](./packages/pusher/README.md) - A service for pushing data provider signed data.
 - [e2e](./packages/e2e/README.md) - End to end test utilizing Mock API, pusher and signed API.
 
+Read the
+[specification](https://docs.google.com/document/d/1-kUPIXSD4ZW1SGs_P8HsejC9k9aHB-NXs9_6-OclnmE/edit#heading=h.i307237rdfda)
+for more details on the architecture and the components.
+
 ## Getting started
 
 The repo uses `pnpm` workspaces. To install the dependencies:


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/109

## Rationale

I wanted to have the high level ideas documented somehere, similarly how it's done with Airseeker. I bookmarked it in Slack and I want to link it in the repo. The services are quite small, but it's the interactions that are important so the document highlights those (e.g. who uses and deploys the services, what calls what, etc...)

The issue also mentions:

> Pushing new docker image should be documented as well.

I've created https://github.com/api3dao/signed-api/issues/124 because we are not published yet (apart from my ad-hoc releases which are specific to me).

> Consider also moving the configuration to a separate README to avoid nested hastag problems.

I don't want to do because it's not an issue and I'd need to update the spec links (which is additional work).