### PR TITLE
Less strict node pnpm requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.10.2
+          version: 8.x
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.10.2
+          version: 8.x
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "signed-api",
   "version": "1.0.0",
   "engines": {
-    "node": "^18.14.0",
-    "pnpm": "^8.10.5"
+    "node": "^18.x",
+    "pnpm": "^8.x"
   },
   "scripts": {
     "build": "pnpm recursive run build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "engines": {
     "node": "^18.14.0",
-    "pnpm": "^8.10.2"
+    "pnpm": "^8.10.5"
   },
   "scripts": {
     "build": "pnpm recursive run build",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "engines": {
     "node": "^18.14.0",
-    "pnpm": "^8.10.2"
+    "pnpm": "^8.10.5"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -2,8 +2,8 @@
   "name": "api",
   "version": "1.0.0",
   "engines": {
-    "node": "^18.14.0",
-    "pnpm": "^8.10.5"
+    "node": "^18.x",
+    "pnpm": "^8.x"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "engines": {
     "node": "^18.14.0",
-    "pnpm": "^8.10.2"
+    "pnpm": "^8.10.5"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -2,8 +2,8 @@
   "name": "e2e",
   "version": "1.0.0",
   "engines": {
-    "node": "^18.14.0",
-    "pnpm": "^8.10.5"
+    "node": "^18.x",
+    "pnpm": "^8.x"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/pusher/package.json
+++ b/packages/pusher/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "engines": {
     "node": "^18.14.0",
-    "pnpm": "^8.10.2"
+    "pnpm": "^8.10.5"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/pusher/package.json
+++ b/packages/pusher/package.json
@@ -2,8 +2,8 @@
   "name": "pusher",
   "version": "0.1.0",
   "engines": {
-    "node": "^18.14.0",
-    "pnpm": "^8.10.5"
+    "node": "^18.x",
+    "pnpm": "^8.x"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,7 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["ethers"],
+      "matchPackageNames": ["ethers", "node"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
@@ -15,13 +11,13 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 1am on the first day of the month"],
-      "groupName": "devDependencies (non-major)"
+      "groupName": "non-major-devDependencies"
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 1am on the first day of the month"],
-      "groupName": "dependencies (non-major)"
+      "groupName": "non-major-dependencies"
     }
   ],
   "rangeStrategy": "bump",
@@ -29,5 +25,7 @@
     "enabled": false
   },
   "reviewers": ["Siegrift"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "dependencyDashboard": false
 }


### PR DESCRIPTION
## Rationale

The `pnpm` is actually getting quite a lot of development and it's annoying because the PRs opened by renovate cannot be merged unless the CI yml file is updated. Both node and pnpm are quite stable so it's better to just force a particular major version of `node` and `pnpm`. 

As a note, we disable the Node.JS because we usually migrate to newer version only when the current nears its EOL.