### PR TITLE
Forward logs to Loki

### DIFF
--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -11,6 +11,21 @@
       "Type": "String",
       "MinLength": 5,
       "Description": "Auth token for Airnode feed."
+    },
+    "grafanaLokiUser": {
+      "Type": "String",
+      "MinLength": 2,
+      "Description": "Username for authenticating Loki API"
+    },
+    "grafanaLokiToken": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Token for authenticating Loki API"
+    },
+    "grafanaLokiEndpoint": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Loki endpoint"
     }
   },
   "Outputs": {
@@ -40,6 +55,31 @@
         "RequiresCompatibilities": ["FARGATE"],
         "ExecutionRoleArn": { "Ref": "ECSTaskRole" },
         "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": "grafana/fluent-bit-plugin-loki:2.9.1-amd64",
+            "Name": "SignedApiLogForwarder",
+            "FirelensConfiguration": {
+              "Type": "fluentbit",
+              "Options": {
+                "enable-ecs-log-metadata": "true"
+              }
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "SignedApiLogsGroup"
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region"
+                },
+                "awslogs-create-group": "true",
+                "awslogs-stream-prefix": "firelens"
+              }
+            },
+            "MemoryReservation": 50
+          },
           {
             "Name": "signed-api-container",
             "Image": "<DOCKER_IMAGE>",
@@ -86,11 +126,33 @@
               }
             ],
             "LogConfiguration": {
-              "LogDriver": "awslogs",
+              "LogDriver": "awsfirelens",
               "Options": {
-                "awslogs-group": { "Ref": "SignedApiLogsGroup" },
-                "awslogs-region": { "Ref": "AWS::Region" },
-                "awslogs-stream-prefix": "ecs"
+                "Name": "grafana-loki",
+                "Url": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "https://",
+                      {
+                        "Ref": "grafanaLokiUser"
+                      },
+                      ":",
+                      {
+                        "Ref": "grafanaLokiToken"
+                      },
+                      "@",
+                      {
+                        "Ref": "grafanaLokiEndpoint"
+                      },
+                      "/loki/api/v1/push"
+                    ]
+                  ]
+                },
+                "Labels": "{app=\"signed-api\",airnodeAddress=\"<AIRNODE_ADDRESS>\"}",
+                "RemoveKeys": "container_id,container_name,ecs_task_definition,source,ecs_cluster",
+                "LabelKeys": "ecs_task_arn",
+                "LineFormat": "json"
               }
             }
           }

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -149,7 +149,7 @@
                     ]
                   ]
                 },
-                "Labels": "{app=\"signed-api\",airnodeAddress=\"<AIRNODE_ADDRESS>\"}",
+                "Labels": "{app=\"signed-api\",airnode=\"<AIRNODE_ADDRESS>\"}",
                 "RemoveKeys": "container_id,container_name,ecs_task_definition,source,ecs_cluster",
                 "LabelKeys": "ecs_task_arn",
                 "LineFormat": "json"


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/123

# Rationale

Implement the same Loki integration as is in https://github.com/api3dao/api-integrations/blob/main/data/cloudformation-template.json.

I tested by deploying the template (with few values edited) and Bedirhan confirmed the logs are recieved by Loki. 