### PR TITLE
Implement various minor fixes

### DIFF
--- a/packages/api/config/signed-api.example.json
+++ b/packages/api/config/signed-api.example.json
@@ -9,5 +9,5 @@
       "delaySeconds": 15
     }
   ],
-  "allowedAirnodes": ["0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"]
+  "allowedAirnodes": ["0xbF3137b0a7574563a23a8fC8badC6537F98197CC"]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage dist",
-    "dev": "nodemon --ext ts,js,json,env --exec \"pnpm ts-node src/dev-server.ts\"",
+    "dev": "nodemon --ext ts,js,json,env --exec \"DEV_SERVER_PORT=${DEV_SERVER_PORT:-8090} pnpm ts-node src/dev-server.ts\"",
     "docker:build": "docker build --target api --tag api3/signed-api:latest ../../",
     "docker:run": "docker run --publish 8090:80 -it --init --volume $(pwd)/config:/app/config --env-file .env --rm api3/signed-api:latest",
     "eslint:check": "eslint . --ext .js,.ts --max-warnings 0",

--- a/packages/api/src/dev-server.ts
+++ b/packages/api/src/dev-server.ts
@@ -4,7 +4,7 @@ import { fetchAndCacheConfig } from './config';
 import { logger } from './logger';
 import { DEFAULT_PORT, startServer } from './server';
 
-const portSchema = z.number().int().positive();
+const portSchema = z.coerce.number().int().positive();
 
 const startDevServer = async () => {
   const config = await fetchAndCacheConfig();

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -15,8 +15,11 @@ export const isIgnored = (signedData: SignedData, ignoreAfterTimestamp: number) 
 export const generateErrorResponse = (
   statusCode: number,
   message: string,
-  detail?: string,
-  extra?: unknown
+  context?: Record<string, unknown>
 ): ApiResponse => {
-  return { statusCode, headers: createResponseHeaders(), body: JSON.stringify({ message, detail, extra }) };
+  return {
+    statusCode,
+    headers: createResponseHeaders(),
+    body: JSON.stringify(context ? { message, context } : { message }),
+  };
 };


### PR DESCRIPTION
## Rationale

@andreogle found various issues when running signed API and Airseeker locally. Specifically:
1. `DEV_SERVER_PORT` not working
2.  `DEV_SERVER_PORT` is not set to 8090 by default (pusher expects signed API on this port)
3. Add more context to `Unauthorized Airnode address` message.
4. Default configuration of signed API has `allowedAirnodes` set to random Airnode instead of the address of the pusher configured for development (with fixed mnemonic).

These are all implemented, and I've slightly changed the function for generating error response.

There was another point, whether pusher needs to use both `.env` and `.secrets.env` but there is a conceptual difference between those so I'm leaving that in place.