### PR TITLE
Build API request correctly

### DIFF
--- a/packages/pusher/src/api-requests/data-provider.test.ts
+++ b/packages/pusher/src/api-requests/data-provider.test.ts
@@ -1,4 +1,5 @@
 import * as adapterModule from '@api3/airnode-adapter';
+import axios from 'axios';
 
 import {
   config,
@@ -8,8 +9,11 @@ import {
 } from '../../test/fixtures';
 import { logger } from '../logger';
 import * as stateModule from '../state';
+import type { Config } from '../validation/schema';
 
 import { makeTemplateRequests } from './data-provider';
+
+jest.mock('axios');
 
 describe(makeTemplateRequests.name, () => {
   it('makes a single template request for multiple beacons', async () => {
@@ -20,6 +24,7 @@ describe(makeTemplateRequests.name, () => {
     const response = await makeTemplateRequests(config.triggers.signedApiUpdates[0]!);
 
     expect(response).toStrictEqual(nodaryTemplateResponses);
+    expect(adapterModule.buildAndExecuteRequest).toHaveBeenCalledTimes(1);
   });
 
   it('handles request failure', async () => {
@@ -36,6 +41,65 @@ describe(makeTemplateRequests.name, () => {
       errorMessage: 'Invalid API key',
       oisTitle: 'Nodary',
       operationTemplateId: '0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd',
+    });
+  });
+
+  it('can uses fixed operational parameters', async () => {
+    const configWithFixedOperationalParameters: Config = {
+      ...config,
+      ois: [
+        {
+          ...config.ois[0]!,
+          endpoints: [
+            {
+              ...config.ois[0]!.endpoints[0]!,
+              fixedOperationParameters: [
+                {
+                  operationParameter: {
+                    in: 'query',
+                    name: 'some-api-parameter',
+                  },
+                  value: 'some-value',
+                },
+              ],
+            },
+          ],
+          apiSpecifications: {
+            ...config.ois[0]!.apiSpecifications,
+            paths: {
+              '/feed/latestV2': {
+                get: {
+                  parameters: [
+                    { in: 'query', name: 'names' },
+                    { in: 'query', name: 'some-api-parameter' },
+                  ],
+                },
+              },
+            },
+            servers: [{ url: 'https://api.nodary.io' }],
+            security: { NodarySecurityScheme1ApiKey: [] },
+          },
+        },
+      ],
+    };
+    const state = stateModule.getInitialState(configWithFixedOperationalParameters);
+    jest.spyOn(stateModule, 'getState').mockReturnValue(state);
+    (axios as jest.MockedFunction<typeof axios>).mockRejectedValue(new Error('network error'));
+
+    await makeTemplateRequests(config.triggers.signedApiUpdates[0]!);
+
+    expect(axios).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith({
+      data: undefined,
+      headers: {
+        'x-nodary-api-key': 'invalid-api-key',
+      },
+      method: 'get',
+      params: {
+        'some-api-parameter': 'some-value',
+      },
+      timeout: 10_000,
+      url: 'https://api.nodary.io/feed/latestV2',
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/132

## Rationale

I realized that Airnode feed actually uses the same logic as in Airnode and the API request is built correctly. I've added a test confirming this.