### PR TITLE
Increase payload size, add default express error handler

### DIFF
--- a/packages/e2e/src/user.test.ts
+++ b/packages/e2e/src/user.test.ts
@@ -1,3 +1,4 @@
+import { go } from '@api3/promise-utils';
 import axios from 'axios';
 
 import { airnode, formatData } from './utils';
@@ -27,3 +28,26 @@ test('respects the delay', async () => {
   expect(realCount).toBeGreaterThan(0);
   expect(delayedCount).toBeGreaterThan(0);
 }, 20_000);
+
+test('ensures Signed API handles requests with huge payloads', async () => {
+  const signedData = {
+    signature:
+      '0x1ea0a64100431adf033ec730547cd3ffd253dd5991336b3d9b9e8dcfe68d82a61bcd9b8b677557a90a025c19ebde1d98608e2fa3462457bb6fe62675518f7f9c1c',
+    timestamp: '1701419743',
+    templateId: '0x031487ca600cd3a26a39206b5b4373f9231f75e4bd23edeb3d5bdc513c147e2a',
+    encodedValue: '0x000000000000000000000000000000000000000000000003d026ef5a02753000',
+    airnode: '0x198539e151Fc2CF7642BFfe95B2b7a3Dc08bE0b7',
+  };
+
+  const goPostData = await go(async () =>
+    axios.post(`http://localhost:8090`, Array.from({ length: 100_000 }).fill(signedData))
+  );
+
+  expect(goPostData.success).toBe(false);
+  const error = goPostData.error as any;
+  expect(error.message).toBe('Request failed with status code 413');
+  expect(error.response.status).toBe(413);
+  expect(error.response.data).toStrictEqual({
+    error: { message: 'request entity too large' },
+  });
+});


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/151

## Rationale

I've set the maximum payload limit to 10mb which should be more then enough for practical use cases. The higher the limit is the bigger is the risk of Signed API being spammed by attackers. We have Airnode allowlist in the config, but even processing such huge payloads incurs some overhead.

I've also added an e2e test that validates this.