### PR TITLE
Add additional signed data checks

### DIFF
--- a/packages/api/src/handlers.test.ts
+++ b/packages/api/src/handlers.test.ts
@@ -100,7 +100,7 @@ describe(batchInsertData.name, () => {
       statusCode: 201,
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      'Not storing signed data because signed data with the same timestamp already exists.',
+      'Not storing signed data because the signed data is not newer than the db sample.',
       expect.any(Object)
     );
     expect(cacheModule.getCache()[storedSignedData.airnode]![storedSignedData.templateId]!).toHaveLength(1);

--- a/packages/api/src/handlers.test.ts
+++ b/packages/api/src/handlers.test.ts
@@ -100,7 +100,7 @@ describe(batchInsertData.name, () => {
       statusCode: 201,
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      'Not storing signed data because the signed data is not newer than the db sample.',
+      'Not storing signed data because the signed data is not newer than what we already have.',
       expect.any(Object)
     );
     expect(cacheModule.getCache()[storedSignedData.airnode]![storedSignedData.templateId]!).toHaveLength(1);

--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -87,7 +87,7 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
     const goReadDb = await go(async () => get(signedData.airnode, signedData.templateId, requestTimestamp));
 
     if (goReadDb.data && requestTimestamp <= Number.parseInt(goReadDb.data.timestamp, 10)) {
-      logger.debug('Not storing signed data because the signed data is not newer than the db sample.', {
+      logger.debug('Not storing signed data because the signed data is not newer than what we already have.', {
         signedData,
       });
       continue;

--- a/packages/api/src/handlers.ts
+++ b/packages/api/src/handlers.ts
@@ -84,7 +84,7 @@ export const batchInsertData = async (requestBody: unknown): Promise<ApiResponse
   // is acceptable, but we only want to store one data for each timestamp.
   for (const signedData of batchSignedData) {
     const requestTimestamp = Number.parseInt(signedData.timestamp, 10);
-    const goReadDb = await go(async () => get(signedData.airnode, signedData.templateId, requestTimestamp));
+    const goReadDb = await go(async () => get(signedData.airnode, signedData.templateId));
 
     if (goReadDb.data && requestTimestamp <= Number.parseInt(goReadDb.data.timestamp, 10)) {
       logger.debug('Not storing signed data because the signed data is not newer than what we already have.', {

--- a/packages/api/src/in-memory-cache.ts
+++ b/packages/api/src/in-memory-cache.ts
@@ -9,8 +9,12 @@ export const ignoreTooFreshData = (signedDatas: SignedData[], ignoreAfterTimesta
   signedDatas.filter((data) => !isIgnored(data, ignoreAfterTimestamp));
 
 // The API is deliberately asynchronous to mimic a database call.
-// eslint-disable-next-line @typescript-eslint/require-await
-export const get = async (airnodeAddress: string, templateId: string, ignoreAfterTimestamp: number) => {
+export const get = async (
+  airnodeAddress: string,
+  templateId: string,
+  ignoreAfterTimestamp = Number.MAX_SAFE_INTEGER
+  // eslint-disable-next-line @typescript-eslint/require-await
+) => {
   logger.debug('Getting signed data.', { airnodeAddress, templateId, ignoreAfterTimestamp });
 
   const signedDataCache = getCache();


### PR DESCRIPTION
Closes #162 

This PR expands the existing signed data freshness check to confirm that the sample we've received is newer than what we already have (if we have something to compare against).

It also checks that the received sample is not older than an hour.

I'm not sure if this satisfies the issue? 🤷 