### PR TITLE
Implement bearer token auth

### DIFF
--- a/packages/airnode-feed/README.md
+++ b/packages/airnode-feed/README.md
@@ -283,11 +283,12 @@ Configuration for the signed APIs. Each signed API is defined by a `signedApiNam
 example:
 
 ```jsonc
-// Defines a single signed API.
+// Defines a single signed API that uses AUTH_TOKEN secret as Bearer token when pushing signed data to signed API.
 "signedApis": [
   {
     "name": "localhost",
-    "url": "http://localhost:8090"
+    "url": "http://localhost:8090",
+    "authToken": "${AUTH_TOKEN}"
   }
 ]
 ```
@@ -303,6 +304,13 @@ The name of the signed API.
 ###### `url`
 
 The URL of the signed API.
+
+#### `authToken`
+
+The authentication token used to authenticate with the signed API. It is recommended to interpolate this value from
+secrets.
+
+If the signed API does not require authentication, set this value to `null`.
 
 #### `ois`
 

--- a/packages/airnode-feed/config/airnode-feed.example.json
+++ b/packages/airnode-feed/config/airnode-feed.example.json
@@ -29,14 +29,15 @@
           "0x1d65c1f1e127a41cebd2339f823d0290322c63f3044380cbac105db8e522ebb9"
         ],
         "fetchInterval": 5,
-        "updateDelay": 30
+        "updateDelay": 0
       }
     ]
   },
   "signedApis": [
     {
       "name": "localhost",
-      "url": "http://localhost:8090"
+      "url": "http://localhost:8090",
+      "authToken": "some-secret-token-for-airnode-feed"
     }
   ],
   "ois": [

--- a/packages/airnode-feed/src/api-requests/signed-api.ts
+++ b/packages/airnode-feed/src/api-requests/signed-api.ts
@@ -42,12 +42,13 @@ export const pushSignedData = async (group: SignedApiUpdate) => {
     }
 
     logger.debug('Posting signed API data.', { group });
-    const provider = signedApis.find((a) => a.name === signedApiName)!;
+    const signedApi = signedApis.find((a) => a.name === signedApiName)!;
     const goAxiosRequest = await go<Promise<unknown>, AxiosError>(async () => {
       logger.debug('Posting batch payload.', { batchPayload });
-      const axiosResponse = await axios.post(provider.url, batchPayload, {
+      const axiosResponse = await axios.post(signedApi.url, batchPayload, {
         headers: {
           'Content-Type': 'application/json',
+          ...(signedApi.authToken ? { Authorization: `Bearer ${signedApi.authToken}` } : {}),
         },
       });
 

--- a/packages/airnode-feed/src/heartbeat/heartbeat.test.ts
+++ b/packages/airnode-feed/src/heartbeat/heartbeat.test.ts
@@ -28,9 +28,9 @@ describe(logHeartbeat.name, () => {
       nodeVersion: '0.1.0',
       currentTimestamp: '1674172803',
       deploymentTimestamp: '1674172800',
-      configHash: '0x1a2a00f22eeab37eb95f8cf1ec10ec89521516db42f41b7ffc6da541d948a54a',
+      configHash: '0x0a36630da26fa987561ff8b692f2015a6fe632bdabcf3dcdd010ccc8262f4a3a',
       signature:
-        '0xd0f84a62705585e03c14ebfda2688a4e4c733aa42a3d13f98d4fe390d482fd1c3e698e91939df28b9565a9de82f3495b053824ffe61239fdd4fa0e4a970523a81b',
+        '0x15fb32178d3c6e30385e448b21a4b9086c715a11e8044513bf3b6a578643f7a327498b59cc3d9442fbd2f3b3b4991f94398727e54558ac24871e2df44d1664e11c',
     };
     const rawConfig = JSON.parse(readFileSync(join(__dirname, '../../config/airnode-feed.example.json'), 'utf8'));
     jest.spyOn(configModule, 'loadRawConfig').mockReturnValue(rawConfig);
@@ -50,12 +50,12 @@ describe(verifyHeartbeatLog.name, () => {
     const jsonLog = {
       context: {
         airnode: '0xbF3137b0a7574563a23a8fC8badC6537F98197CC',
-        configHash: '0x1a2a00f22eeab37eb95f8cf1ec10ec89521516db42f41b7ffc6da541d948a54a',
+        configHash: '0x0a36630da26fa987561ff8b692f2015a6fe632bdabcf3dcdd010ccc8262f4a3a',
         currentTimestamp: '1674172803',
         deploymentTimestamp: '1674172800',
         nodeVersion: '0.1.0',
         signature:
-          '0xd0f84a62705585e03c14ebfda2688a4e4c733aa42a3d13f98d4fe390d482fd1c3e698e91939df28b9565a9de82f3495b053824ffe61239fdd4fa0e4a970523a81b',
+          '0x15fb32178d3c6e30385e448b21a4b9086c715a11e8044513bf3b6a578643f7a327498b59cc3d9442fbd2f3b3b4991f94398727e54558ac24871e2df44d1664e11c',
         stage: 'test',
       },
       level: 'info',
@@ -81,10 +81,10 @@ describe(stringifyUnsignedHeartbeatPayload.name, () => {
         nodeVersion: '0.1.0',
         currentTimestamp: '1674172803',
         deploymentTimestamp: '1674172800',
-        configHash: '0x1a2a00f22eeab37eb95f8cf1ec10ec89521516db42f41b7ffc6da541d948a54a',
+        configHash: '0x0a36630da26fa987561ff8b692f2015a6fe632bdabcf3dcdd010ccc8262f4a3a',
       })
     ).toBe(
-      '{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","configHash":"0x1a2a00f22eeab37eb95f8cf1ec10ec89521516db42f41b7ffc6da541d948a54a","currentTimestamp":"1674172803","deploymentTimestamp":"1674172800","nodeVersion":"0.1.0","stage":"test"}'
+      '{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","configHash":"0x0a36630da26fa987561ff8b692f2015a6fe632bdabcf3dcdd010ccc8262f4a3a","currentTimestamp":"1674172803","deploymentTimestamp":"1674172800","nodeVersion":"0.1.0","stage":"test"}'
     );
   });
 });

--- a/packages/airnode-feed/src/validation/schema.test.ts
+++ b/packages/airnode-feed/src/validation/schema.test.ts
@@ -52,8 +52,8 @@ test('ensures nodeVersion matches Airnode feed version', async () => {
 test('ensures signed API names are unique', () => {
   expect(() =>
     signedApisSchema.parse([
-      { name: 'foo', url: 'https://example.com' },
-      { name: 'foo', url: 'https://example.com' },
+      { name: 'foo', url: 'https://example.com', authToken: null },
+      { name: 'foo', url: 'https://example.com', authToken: null },
     ])
   ).toThrow(
     new ZodError([
@@ -65,10 +65,11 @@ test('ensures signed API names are unique', () => {
     ])
   );
 
-  expect(signedApisSchema.parse([{ name: 'foo', url: 'https://example.com' }])).toStrictEqual([
+  expect(signedApisSchema.parse([{ name: 'foo', url: 'https://example.com', authToken: null }])).toStrictEqual([
     {
       name: 'foo',
       url: 'https://example.com',
+      authToken: null,
     },
   ]);
 });

--- a/packages/airnode-feed/src/validation/schema.ts
+++ b/packages/airnode-feed/src/validation/schema.ts
@@ -223,6 +223,7 @@ const validateTriggerReferences: SuperRefinement<{
 export const signedApiSchema = z.strictObject({
   name: z.string(),
   url: z.string().url(),
+  authToken: z.string().nullable(),
 });
 
 export type SignedApi = z.infer<typeof signedApiSchema>;

--- a/packages/airnode-feed/test/fixtures.ts
+++ b/packages/airnode-feed/test/fixtures.ts
@@ -46,6 +46,7 @@ export const config: Config = {
     {
       name: 'localhost',
       url: 'http://localhost:8090',
+      authToken: null,
     },
   ],
   ois: [

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -145,15 +145,17 @@ The API needs to be configured with endpoints to be served. This is done via the
 ```jsonc
 // Defines two endpoints.
 "endpoints": [
-  // Serves the non-delayed data on URL path "/real-time".
+  // Serves the non-delayed data on URL path "/real-time". Requesters need to provide the "some-secret-token" as Bearer token.
   {
     "urlPath": "/real-time",
-    "delaySeconds": 0
+    "delaySeconds": 0,
+    "authTokens": ["some-secret-token"],
   },
-  // Serves the data delayed by 15 seconds on URL path "/delayed".
+  // Serves the data delayed by 15 seconds on URL path "/delayed". No authentication is required.
   {
     "urlPath": "/delayed",
-    "delaySeconds": 15
+    "delaySeconds": 15,
+    "authTokens": null,
   }
 ]
 ```
@@ -170,6 +172,14 @@ dashes.
 ###### `delaySeconds`
 
 The delay in seconds for the endpoint. The endpoint will only serve data that is older than the delay.
+
+###### `authTokens`
+
+The nonempty list of
+[Bearer authentication tokens](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#bearer) allowed to query
+the data.
+
+In case the endpoint should be publicly available, set the value to `null`.
 
 #### `cache` _(optional)_
 
@@ -190,8 +200,8 @@ The maximum age of the cache in seconds. The cache is cleared after this time.
 
 #### `allowedAirnodes`
 
-The list of allowed Airnode addresses. If the list is empty, no Airnode is allowed. To whitelist all Airnodes, set the
-value to `"*"` instead of an array.
+The list of allowed Airnodes with authorization details. If the list is empty, no Airnode is allowed. To whitelist all
+Airnodes, set the value to `"*"` instead of an array.
 
 Example:
 
@@ -203,9 +213,32 @@ Example:
 or
 
 ```jsonc
-// Allows pushing signed data only from the specific Airnode.
-"allowedAirnodes": ["0xB47E3D8734780430ee6EfeF3c5407090601Dcd15"]
+// Allows pushing signed data only for the specific Airnode. No authorization is required to push the data.
+"allowedAirnodes": [ { "address": "0xB47E3D8734780430ee6EfeF3c5407090601Dcd15", "authTokens": null } ]
 ```
+
+or
+
+```jsonc
+// Allows pushing signed data only for the specific Airnode. The pusher needs to authorize with one of the specific tokens.
+"allowedAirnodes": { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["some-secret-token-for-airnode-feed"] }
+```
+
+##### `allowedAirnodes[n]`
+
+One of the allowed Airnodes.
+
+###### `address`
+
+The address of the Airnode. The address must be a valid Ethereum address.
+
+###### `authTokens`
+
+The nonempty list of
+[Bearer authentication tokens](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#bearer).
+
+To allow pushing data without any authorization, set the value to `null`. The API validates the data, but this is not
+recommended.
 
 ##### `stage`
 

--- a/packages/api/config/signed-api.example.json
+++ b/packages/api/config/signed-api.example.json
@@ -2,14 +2,18 @@
   "endpoints": [
     {
       "urlPath": "/real-time",
+      "authTokens": ["some-secret-token"],
       "delaySeconds": 0
     },
     {
       "urlPath": "/delayed",
+      "authTokens": null,
       "delaySeconds": 15
     }
   ],
-  "allowedAirnodes": ["0xbF3137b0a7574563a23a8fC8badC6537F98197CC"],
+  "allowedAirnodes": [
+    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["some-secret-token-for-airnode-feed"] }
+  ],
   "stage": "local",
   "version": "0.1.0"
 }

--- a/packages/api/src/schema.test.ts
+++ b/packages/api/src/schema.test.ts
@@ -23,12 +23,16 @@ describe('endpointSchema', () => {
         path: ['urlPath'],
       },
     ]);
-    expect(() => endpointSchema.parse({ urlPath: '', delaySeconds: 0 })).toThrow(expectedError);
-    expect(() => endpointSchema.parse({ urlPath: '/', delaySeconds: 0 })).toThrow(expectedError);
-    expect(() => endpointSchema.parse({ urlPath: 'url-path', delaySeconds: 0 })).toThrow(expectedError);
-    expect(() => endpointSchema.parse({ urlPath: 'url-path', delaySeconds: 0 })).toThrow(expectedError);
+    expect(() => endpointSchema.parse({ urlPath: '', delaySeconds: 0, authTokens: null })).toThrow(expectedError);
+    expect(() => endpointSchema.parse({ urlPath: '/', delaySeconds: 0, authTokens: null })).toThrow(expectedError);
+    expect(() => endpointSchema.parse({ urlPath: 'url-path', delaySeconds: 0, authTokens: null })).toThrow(
+      expectedError
+    );
+    expect(() => endpointSchema.parse({ urlPath: 'url-path', delaySeconds: 0, authTokens: null })).toThrow(
+      expectedError
+    );
 
-    expect(() => endpointSchema.parse({ urlPath: '/url-path', delaySeconds: 0 })).not.toThrow();
+    expect(() => endpointSchema.parse({ urlPath: '/url-path', delaySeconds: 0, authTokens: null })).not.toThrow();
   });
 });
 
@@ -36,8 +40,8 @@ describe('endpointsSchema', () => {
   it('ensures each urlPath is unique', () => {
     expect(() =>
       endpointsSchema.parse([
-        { urlPath: '/url-path', delaySeconds: 0 },
-        { urlPath: '/url-path', delaySeconds: 0 },
+        { urlPath: '/url-path', delaySeconds: 0, authTokens: null },
+        { urlPath: '/url-path', delaySeconds: 0, authTokens: null },
       ])
     ).toThrow(
       new ZodError([
@@ -127,12 +131,12 @@ describe('allowed Airnodes schema', () => {
     const allValid = allowedAirnodesSchema.parse('*');
     expect(allValid).toBe('*');
 
-    expect(
+    expect(() =>
       allowedAirnodesSchema.parse([
-        '0xB47E3D8734780430ee6EfeF3c5407090601Dcd15',
-        '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11',
+        { address: '0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', authTokens: ['token1'] },
+        { address: '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11', authTokens: null },
       ])
-    ).toStrictEqual(['0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11']);
+    ).not.toThrow();
   });
 
   it('disallows empty list', () => {

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -12,6 +12,7 @@ export const endpointSchema = z.strictObject({
   urlPath: z
     .string()
     .regex(/^\/[\dA-Za-z-]+$/, 'Must start with a slash and contain only alphanumeric characters and dashes'),
+  authTokens: z.array(z.string()).nonempty().nullable(),
   delaySeconds: z.number().nonnegative().int(),
 });
 
@@ -24,7 +25,16 @@ export const endpointsSchema = z
     'Each "urlPath" of an endpoint must be unique'
   );
 
-export const allowedAirnodesSchema = z.union([z.literal('*'), z.array(evmAddressSchema).nonempty()]);
+const allowedAirnodeSchema = z.strictObject({
+  address: evmAddressSchema,
+  authTokens: z.array(z.string()).nonempty().nullable(),
+});
+
+export type AllowedAirnode = z.infer<typeof allowedAirnodeSchema>;
+
+export const allowedAirnodesSchema = z.union([z.literal('*'), z.array(allowedAirnodeSchema).nonempty()]);
+
+export type AllowedAirnodes = z.infer<typeof allowedAirnodesSchema>;
 
 export const cacheSchema = z.strictObject({
   type: z.union([z.literal('browser'), z.literal('cdn')]),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -19,7 +19,7 @@ export const startServer = (config: Config, port: number) => {
     logger.info('Received request "POST /".');
     logger.debug('Request details.', { body: req.body });
 
-    const result = await batchInsertData(req.body);
+    const result = await batchInsertData(req.headers.authorization, req.body);
     res.status(result.statusCode).header(result.headers).send(result.body);
 
     logger.debug('Responded to request "POST /".', result);
@@ -36,13 +36,13 @@ export const startServer = (config: Config, port: number) => {
 
   for (const endpoint of config.endpoints) {
     logger.info('Registering endpoint.', endpoint);
-    const { urlPath, delaySeconds } = endpoint;
+    const { urlPath } = endpoint;
 
     app.get(`${urlPath}/:airnodeAddress`, async (req, res) => {
-      logger.info('Received request "GET /:airnode".');
+      logger.info(`Received request "GET ${urlPath}/:airnode".`);
       logger.debug('Request details.', { body: req.body, params: req.params });
 
-      const result = await getData(req.params.airnodeAddress, delaySeconds);
+      const result = await getData(endpoint, req.headers.authorization, req.params.airnodeAddress);
       res.status(result.statusCode).header(result.headers).send(result.body);
 
       logger.debug('Responded to request "GET /:airnode".', result);

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -23,3 +23,12 @@ export const generateErrorResponse = (
     body: JSON.stringify(context ? { message, context } : { message }),
   };
 };
+
+export const extractBearerToken = (authorizationHeader: string | undefined) => {
+  if (!authorizationHeader) return null;
+
+  const [type, token] = authorizationHeader.split(' ');
+  if (type !== 'Bearer' || !token) return null;
+
+  return token;
+};

--- a/packages/e2e/src/airnode-feed/airnode-feed.json
+++ b/packages/e2e/src/airnode-feed/airnode-feed.json
@@ -59,7 +59,8 @@
   "signedApis": [
     {
       "name": "localhost",
-      "url": "${SIGNED_API_URL}"
+      "url": "${SIGNED_API_URL}",
+      "authToken": "some-secret-token-for-airnode-feed"
     }
   ],
   "ois": [

--- a/packages/e2e/src/signed-api/signed-api.json
+++ b/packages/e2e/src/signed-api/signed-api.json
@@ -2,14 +2,18 @@
   "endpoints": [
     {
       "urlPath": "/real-time",
+      "authTokens": ["some-secret-token"],
       "delaySeconds": 0
     },
     {
       "urlPath": "/delayed",
-      "delaySeconds": 10
+      "authTokens": null,
+      "delaySeconds": 15
     }
   ],
-  "allowedAirnodes": ["0xbF3137b0a7574563a23a8fC8badC6537F98197CC"],
+  "allowedAirnodes": [
+    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["some-secret-token-for-airnode-feed"] }
+  ],
   "stage": "e2e-test",
   "version": "0.1.0"
 }

--- a/packages/e2e/src/user.test.ts
+++ b/packages/e2e/src/user.test.ts
@@ -8,7 +8,9 @@ test('respects the delay', async () => {
   let [realCount, delayedCount] = [0, 0];
 
   while (Date.now() - start < 15_000) {
-    const realTimeResponse = await axios.get(`http://localhost:8090/real-time/${airnode}`);
+    const realTimeResponse = await axios.get(`http://localhost:8090/real-time/${airnode}`, {
+      headers: { Authorization: `Bearer some-secret-token` },
+    });
     const realTimeData = formatData(realTimeResponse.data);
     const delayedResponse = await axios.get(`http://localhost:8090/delayed/${airnode}`);
     const delayedData = formatData(delayedResponse.data);

--- a/packages/e2e/src/user.ts
+++ b/packages/e2e/src/user.ts
@@ -7,7 +7,9 @@ const main = async () => {
   while (true) {
     logger.debug('Making requests');
 
-    const realTimeResponse = await axios.get(`http://localhost:8090/real-time/${airnode}`);
+    const realTimeResponse = await axios.get(`http://localhost:8090/real-time/${airnode}`, {
+      headers: { Authorization: `Bearer some-secret-token` },
+    });
     logger.debug('Response "GET /real-time".', formatData(realTimeResponse.data));
 
     const delayedResponse = await axios.get(`http://localhost:8090/delayed/${airnode}`);


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/22

## Rationale

The Signed API configuration changes are inspired by the following idea:
```
{
  "endpoints": [
    {
      "urlPath": "/default",
    -> "authTokens": ["token"],
      "delaySeconds": 0
    },
    {
      "urlPath": "/delayed",
   -> "authTokens": null,
      "delaySeconds": 15
    }
  ],
  "allowedAirnodes": [
    {
      "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
   -> "authTokens": ["airnode-token-1", "airnode-token-2"]
    }
  ],
  "stage": "local",
  "version": "0.1.0"
}
```

Each endpoint can have Bearer token authentication. Similarly for the endpoint to push the data from Airnode feed. Read the configuration changes (READMEs) and the changes in the example configuration files.

Related
- [x] Readme config changes
- [x] Update spec (high level reasoning why we use auth)