### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There is a script that automates the process of creating new NPM packages and Do
 4. `pnpm run publish:airnode-feed && pnpm run publish:signed-api` - To publish Airnode feed and Signed API package to
    NPM.
 5. `git push --follow-tags` - Push the tagged version commit upstream.
-6. `pnpm run create-release:docker` - To build the Docker images and tag them correctly. The script uses the current
+6. Do a GitHub release for the specific tag.
+7. `pnpm run create-release:docker` - To build the Docker images and tag them correctly. The script uses the current
    package.json version so it expects the NPM release is done first.
-7. The command outputs the publish instructions to push the images.
+8. The command outputs the publish instructions to push the images.

--- a/scripts/create-npm-release.ts
+++ b/scripts/create-npm-release.ts
@@ -111,10 +111,10 @@ const main = () => {
 
   console.info('Creating new commit...');
   execSyncWithErrorHandling('git add .');
-  execSyncWithErrorHandling(`git commit -m "${newVersion}"`);
+  execSyncWithErrorHandling(`git commit -m "v${newVersion}"`);
 
   console.info('Creating new annotated git tag...');
-  execSyncWithErrorHandling(`git tag -a ${newVersion} -m "${newVersion}"`);
+  execSyncWithErrorHandling(`git tag -a v${newVersion} -m "v${newVersion}"`);
 
   console.info('');
   console.info('The airnode-feed and signed-api packages have been bumped to the new version.');


### PR DESCRIPTION
I successfully did a [0.2.0 release](https://github.com/api3dao/signed-api/releases/tag/0.2.0), but I realized that GH adds a `v` before the git tag, so I am adding that back for consistency. I will leave the existing tag in place though.

Also, the README was missing an instruction to create a GH release.