### PR TITLE
Create config directory in terraform templates

### DIFF
--- a/packages/performance-test/airnode-feed/cloudformation.json
+++ b/packages/performance-test/airnode-feed/cloudformation.json
@@ -37,7 +37,7 @@
             "EntryPoint": [
               "/bin/sh",
               "-c",
-              "echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - <AIRNODE_FEED_CONFIG_URL> >> ./config/airnode-feed.json && node dist/src/index.js"
+              "mkdir config && echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - <AIRNODE_FEED_CONFIG_URL> >> ./config/airnode-feed.json && node dist/src/index.js"
             ],
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/packages/performance-test/signed-api/cloudformation.json
+++ b/packages/performance-test/signed-api/cloudformation.json
@@ -44,7 +44,7 @@
             "EntryPoint": [
               "/bin/sh",
               "-c",
-              "wget -O - <SIGNED_API_CONFIG_URL> >> ./config/signed-api.json && node dist/src/index.js"
+              "mkdir config && wget -O - <SIGNED_API_CONFIG_URL> >> ./config/signed-api.json && node dist/src/index.js"
             ],
             "PortMappings": [
               {

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -44,7 +44,7 @@
             "EntryPoint": [
               "/bin/sh",
               "-c",
-              "wget -O - <SIGNED_API_CONFIGURATION_URL> >> ./config/signed-api.json && node dist/src/index.js"
+              "mkdir config && wget -O - <SIGNED_API_CONFIGURATION_URL> >> ./config/signed-api.json && node dist/src/index.js"
             ],
             "PortMappings": [
               {


### PR DESCRIPTION
Relates to https://github.com/api3dao/signed-api/issues/186#issuecomment-1874303494

We need to change the TF templates, because after the NPM publishing the `config` directory will no longer be part of the image. 