### PR TITLE
Support caching on AWS CloudFront

### DIFF
--- a/packages/signed-api/README.md
+++ b/packages/signed-api/README.md
@@ -185,16 +185,17 @@ In case the endpoint should be publicly available, set the value to `null`.
 
 #### `cache` _(optional)_
 
-Configures the cache for the API endpoints.
+Configures the cache (specifically caching headers) for the API endpoints using the GET HTTP method.
 
-Defaults to no cache.
+Defaults to no cache (no headers).
 
 ##### `type`
 
 The type of the cache. Options:
 
-- `browser` - Uses the browser cache.
-- `cdn` - Uses the CDN cache. The CDN network needs to support `cdn-cache-control` header.
+- `browser` - Sets the standard `cache-control: max-age=XYZ` header.
+- `cdn` - Similar to `browser` cache, but also sets the `cdn-cache-control` to the same value as `cache-control`.
+  Setting both headers is necessary to support CDNs which do not support `cdn-cache-control` header.
 
 ##### `maxAgeSeconds`
 

--- a/packages/signed-api/src/handlers.ts
+++ b/packages/signed-api/src/handlers.ts
@@ -137,7 +137,7 @@ export const batchInsertData = async (
 
   return {
     statusCode: 201,
-    headers: createResponseHeaders(getConfig().cache),
+    headers: createResponseHeaders(), // Inserting data is done through POST request, so we do not cache it.
     body: JSON.stringify({
       count: newSignedData.length,
       skipped: batchSignedData.length - newSignedData.length,

--- a/packages/signed-api/src/headers.test.ts
+++ b/packages/signed-api/src/headers.test.ts
@@ -30,7 +30,7 @@ describe(createResponseHeaders.name, () => {
       'content-type': 'application/json',
       'access-control-allow-origin': '*',
       'access-control-allow-methods': '*',
-      'cache-control': 'no-store',
+      'cache-control': 'max-age=3600',
       'cdn-cache-control': 'max-age=3600',
     };
     expect(

--- a/packages/signed-api/src/headers.ts
+++ b/packages/signed-api/src/headers.ts
@@ -20,7 +20,7 @@ export const createResponseHeaders = (cache?: Cache | undefined) => {
     case 'cdn': {
       return {
         ...COMMON_HEADERS,
-        'cache-control': 'no-store', // Disable browser-caching
+        'cache-control': `max-age=${maxAgeSeconds}`, // It does not hurt to set the browser cache as well.
         'cdn-cache-control': `max-age=${maxAgeSeconds}`,
       };
     }


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/193

AWS CloudFront does not support caching based on custom header nor does recognize `cdn-cache-control`. The original issue mentioned making the cache headers more generic, but I don't think it's necessary. We can use both the standard `cache-control` for browser-cache (which is recognized by CloudFront) and the `cdn-cache-control`. 

The PR also removes these headers from POST response (which does not make sense).