### PR TITLE
Remove pnpm from engine field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "signed-api",
   "version": "0.4.0",
   "engines": {
-    "node": ">=18.19.0",
-    "pnpm": "^8.14.1"
+    "node": ">=18.19.0"
   },
   "scripts": {
     "build": "pnpm recursive run build",

--- a/packages/airnode-feed/package.json
+++ b/packages/airnode-feed/package.json
@@ -2,8 +2,7 @@
   "name": "@api3/airnode-feed",
   "version": "0.4.0",
   "engines": {
-    "node": ">=18.19.0",
-    "pnpm": "^8.14.1"
+    "node": ">=18.19.0"
   },
   "files": [
     "dist",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -2,8 +2,7 @@
   "name": "e2e",
   "version": "1.0.0",
   "engines": {
-    "node": ">=18.19.0",
-    "pnpm": "^8.14.1"
+    "node": ">=18.19.0"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/performance-test/package.json
+++ b/packages/performance-test/package.json
@@ -2,8 +2,7 @@
   "name": "e2e",
   "version": "1.1.0",
   "engines": {
-    "node": ">=18.19.0",
-    "pnpm": "^8.14.1"
+    "node": ">=18.19.0"
   },
   "scripts": {
     "tsc": "tsc --project .",

--- a/packages/signed-api/package.json
+++ b/packages/signed-api/package.json
@@ -2,8 +2,7 @@
   "name": "@api3/signed-api",
   "version": "0.4.0",
   "engines": {
-    "node": ">=18.19.0",
-    "pnpm": "^8.14.1"
+    "node": ">=18.19.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
I am a bit tired of the frequent updates of pnpm field, for example https://github.com/api3dao/signed-api/pull/205.

Morover, this can cause warning for consumers who use other package manager (e.g. npm or yarn) and it provides very little benefit. I suggest removing it altogether.