### PR TITLE
AWS Signed API deployment without load balancer

### DIFF
--- a/packages/signed-api/config/signed-api.example.json
+++ b/packages/signed-api/config/signed-api.example.json
@@ -1,19 +1,12 @@
 {
   "endpoints": [
     {
-      "urlPath": "/real-time",
-      "authTokens": ["${REAL_TIME_ENDPOINT_AUTH_TOKEN}"],
-      "delaySeconds": 0
-    },
-    {
-      "urlPath": "/delayed",
+      "urlPath": "/real",
       "authTokens": null,
-      "delaySeconds": 15
+      "delaySeconds": 0
     }
   ],
-  "allowedAirnodes": [
-    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"] }
-  ],
+  "allowedAirnodes": "*",
   "stage": "local",
   "version": "0.4.0"
 }

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -11,21 +11,6 @@
       "Type": "String",
       "MinLength": 5,
       "Description": "Auth token for Airnode feed."
-    },
-    "grafanaLokiUser": {
-      "Type": "String",
-      "MinLength": 2,
-      "Description": "Username for authenticating Loki API"
-    },
-    "grafanaLokiToken": {
-      "Type": "String",
-      "MinLength": 10,
-      "Description": "Token for authenticating Loki API"
-    },
-    "grafanaLokiEndpoint": {
-      "Type": "String",
-      "MinLength": 10,
-      "Description": "Loki endpoint"
     }
   },
   "Outputs": {
@@ -55,31 +40,6 @@
         "RequiresCompatibilities": ["FARGATE"],
         "ExecutionRoleArn": { "Ref": "ECSTaskRole" },
         "ContainerDefinitions": [
-          {
-            "Essential": true,
-            "Image": "grafana/fluent-bit-plugin-loki:2.9.1-amd64",
-            "Name": "SignedApiLogForwarder",
-            "FirelensConfiguration": {
-              "Type": "fluentbit",
-              "Options": {
-                "enable-ecs-log-metadata": "true"
-              }
-            },
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "SignedApiLogsGroup"
-                },
-                "awslogs-region": {
-                  "Ref": "AWS::Region"
-                },
-                "awslogs-create-group": "true",
-                "awslogs-stream-prefix": "firelens"
-              }
-            },
-            "MemoryReservation": 50
-          },
           {
             "Name": "signed-api-container",
             "Image": "<DOCKER_IMAGE>",
@@ -111,7 +71,7 @@
               },
               {
                 "Name": "LOG_LEVEL",
-                "Value": "info"
+                "Value": "debug"
               }
             ],
             "EntryPoint": [
@@ -126,33 +86,11 @@
               }
             ],
             "LogConfiguration": {
-              "LogDriver": "awsfirelens",
+              "LogDriver": "awslogs",
               "Options": {
-                "Name": "grafana-loki",
-                "Url": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "https://",
-                      {
-                        "Ref": "grafanaLokiUser"
-                      },
-                      ":",
-                      {
-                        "Ref": "grafanaLokiToken"
-                      },
-                      "@",
-                      {
-                        "Ref": "grafanaLokiEndpoint"
-                      },
-                      "/loki/api/v1/push"
-                    ]
-                  ]
-                },
-                "Labels": "{app=\"signed-api\",airnode=\"<AIRNODE_ADDRESS>\"}",
-                "RemoveKeys": "container_id,container_name,ecs_task_definition,source,ecs_cluster",
-                "LabelKeys": "ecs_task_arn",
-                "LineFormat": "json"
+                "awslogs-group": { "Ref": "SignedApiLogsGroup" },
+                "awslogs-region": { "Ref": "AWS::Region" },
+                "awslogs-stream-prefix": "ecs"
               }
             }
           }

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -7,7 +7,7 @@
     "SignedApiLogsGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/ecs/signedApi-<ID>",
+        "LogGroupName": "/ecs/signedApi-id1",
         "RetentionInDays": 7
       }
     },
@@ -23,7 +23,7 @@
         "ContainerDefinitions": [
           {
             "Name": "signed-api-container",
-            "Image": "<DOCKER_IMAGE>",
+            "Image": "api3/signed-api:0.4.0",
             "Environment": [
               {
                 "Name": "SECRETS_ENV",
@@ -41,7 +41,7 @@
             "EntryPoint": [
               "/bin/sh",
               "-c",
-              "mkdir config && echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - <SIGNED_API_URL_CONFIGURATION> >> ./config/signed-api.json && node dist/src/index.js"
+              "mkdir config && echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/signed-api/cf-without-elb/packages/signed-api/config/signed-api.example.json >> ./config/signed-api.json && node dist/src/index.js"
             ],
             "PortMappings": [
               {
@@ -80,7 +80,7 @@
     "ECSCluster": {
       "Type": "AWS::ECS::Cluster",
       "Properties": {
-        "ClusterName": "signed-api-cluster-<ID>"
+        "ClusterName": "signed-api-cluster-id1"
       }
     },
     "VPC": {

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -1,27 +1,8 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "CloudFormation template for deploying Signed API",
-  "Parameters": {
-    "realTimeEndpointAuthToken": {
-      "Type": "String",
-      "MinLength": 5,
-      "Description": "Auth token for accessing real time data."
-    },
-    "airnodeFeedAuthToken": {
-      "Type": "String",
-      "MinLength": 5,
-      "Description": "Auth token for Airnode feed."
-    }
-  },
-  "Outputs": {
-    "LoadBalancerDNS": {
-      "Description": "The DNS name of the load balancer",
-      "Value": { "Fn::GetAtt": ["ELB", "DNSName"] },
-      "Export": {
-        "Name": { "Fn::Sub": "${AWS::StackName}-LoadBalancerDNS" }
-      }
-    }
-  },
+  "Parameters": {},
+  "Outputs": {},
   "Resources": {
     "SignedApiLogsGroup": {
       "Type": "AWS::Logs::LogGroup",
@@ -34,8 +15,8 @@
       "Type": "AWS::ECS::TaskDefinition",
       "Properties": {
         "Family": "signed-api-task",
-        "Cpu": "1024",
-        "Memory": "2048",
+        "Cpu": "256",
+        "Memory": "512",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": ["FARGATE"],
         "ExecutionRoleArn": { "Ref": "ECSTaskRole" },
@@ -46,24 +27,7 @@
             "Environment": [
               {
                 "Name": "SECRETS_ENV",
-                "Value": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "REAL_TIME_ENDPOINT_AUTH_TOKEN",
-                      "=",
-                      {
-                        "Ref": "realTimeEndpointAuthToken"
-                      },
-                      "\\n",
-                      "AIRNODE_FEED_AUTH_TOKEN",
-                      "=",
-                      {
-                        "Ref": "airnodeFeedAuthToken"
-                      }
-                    ]
-                  ]
-                }
+                "Value": ""
               },
               {
                 "Name": "CONFIG_SOURCE",
@@ -71,7 +35,7 @@
               },
               {
                 "Name": "LOG_LEVEL",
-                "Value": "debug"
+                "Value": "info"
               }
             ],
             "EntryPoint": [
@@ -99,7 +63,6 @@
     },
     "SignedApiService": {
       "Type": "AWS::ECS::Service",
-      "DependsOn": "SignedApiListener",
       "Properties": {
         "Cluster": { "Ref": "ECSCluster" },
         "LaunchType": "FARGATE",
@@ -111,52 +74,13 @@
             "SecurityGroups": [{ "Ref": "ECSSecurityGroup" }],
             "AssignPublicIp": "ENABLED"
           }
-        },
-        "LoadBalancers": [
-          {
-            "ContainerName": "signed-api-container",
-            "ContainerPort": 80,
-            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
-          }
-        ]
+        }
       }
     },
     "ECSCluster": {
       "Type": "AWS::ECS::Cluster",
       "Properties": {
         "ClusterName": "signed-api-cluster-<ID>"
-      }
-    },
-    "ELB": {
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "Properties": {
-        "Name": "signed-api-elb-<ID>",
-        "Subnets": [{ "Ref": "PublicSubnet1" }, { "Ref": "PublicSubnet2" }],
-        "SecurityGroups": [{ "Ref": "ELBSecurityGroup" }],
-        "Scheme": "internet-facing"
-      }
-    },
-    "SignedApiListener": {
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
-      "Properties": {
-        "DefaultActions": [
-          {
-            "Type": "forward",
-            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
-          }
-        ],
-        "LoadBalancerArn": { "Ref": "ELB" },
-        "Port": 80,
-        "Protocol": "HTTP"
-      }
-    },
-    "SignedApiTargetGroup": {
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "Properties": {
-        "Port": 80,
-        "Protocol": "HTTP",
-        "VpcId": { "Ref": "VPC" },
-        "TargetType": "ip"
       }
     },
     "VPC": {
@@ -234,21 +158,6 @@
             "IpProtocol": "tcp",
             "FromPort": 80,
             "ToPort": 80,
-            "SourceSecurityGroupId": { "Ref": "ELBSecurityGroup" }
-          }
-        ]
-      }
-    },
-    "ELBSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Security Group for ELB",
-        "VpcId": { "Ref": "VPC" },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": 80,
-            "ToPort": 80,
             "CidrIp": "0.0.0.0/0"
           }
         ]
@@ -281,11 +190,6 @@
                   "Action": [
                     "ec2:AuthorizeSecurityGroupIngress",
                     "ec2:Describe*",
-                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                    "elasticloadbalancing:DeregisterTargets",
-                    "elasticloadbalancing:Describe*",
-                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                    "elasticloadbalancing:RegisterTargets",
                     "ec2:CreateSecurityGroup",
                     "ec2:DeleteSecurityGroup",
                     "logs:CreateLogGroup",

--- a/packages/signed-api/deployment/cloudformation-template.json
+++ b/packages/signed-api/deployment/cloudformation-template.json
@@ -111,7 +111,7 @@
               },
               {
                 "Name": "LOG_LEVEL",
-                "Value": "debug"
+                "Value": "info"
               }
             ],
             "EntryPoint": [


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/213

## Rationale

Unfortunately, It's [not possible to have a static IP for AWS Fargate](https://repost.aws/knowledge-center/ecs-fargate-static-elastic-ip-address). This means the IP changes after each restart/redeployment and each time we need to update the CDN routing. Also, the IP cannot be listed in CloudFormation output parameters and is only available in the currently deployed task configuration (ES2 -> Clusters -> Services -> Tasks). We can get the URL via AWS CLI though.

If we relax the requirement of static IP we can use the CloudFormation template in this PR. Each Signed API redeployment/restart would require immediate change in CDN distribution, incurring some delay while the update takes place.

During my research I haven't seen other "confirmed" solutions that work around the problem that the IP is bound to the task (not service). I saw threads like [this](https://stackoverflow.com/questions/68651457/how-to-route-traffic-to-ecs-fargate-instance-without-an-application-load-balance#comment121377541_68665985) or [this](https://serverfault.com/a/1037243) which support using the LB for this purpose.