### PR TITLE
Fix timestamps not used when signing payload

### DIFF
--- a/packages/airnode-feed/src/api-requests/data-provider.test.ts
+++ b/packages/airnode-feed/src/api-requests/data-provider.test.ts
@@ -21,7 +21,7 @@ describe(makeTemplateRequests.name, () => {
     jest.spyOn(stateModule, 'getState').mockReturnValue(state);
     jest.spyOn(adapterModule, 'buildAndExecuteRequest').mockResolvedValue(nodaryTemplateRequestResponseData);
 
-    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20')); // 1674172800
 
     const response = await makeTemplateRequests(config.triggers.signedApiUpdates[0]);
 

--- a/packages/airnode-feed/src/api-requests/data-provider.test.ts
+++ b/packages/airnode-feed/src/api-requests/data-provider.test.ts
@@ -21,6 +21,8 @@ describe(makeTemplateRequests.name, () => {
     jest.spyOn(stateModule, 'getState').mockReturnValue(state);
     jest.spyOn(adapterModule, 'buildAndExecuteRequest').mockResolvedValue(nodaryTemplateRequestResponseData);
 
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+
     const response = await makeTemplateRequests(config.triggers.signedApiUpdates[0]);
 
     expect(response).toStrictEqual(nodaryTemplateResponses);

--- a/packages/airnode-feed/src/api-requests/data-provider.ts
+++ b/packages/airnode-feed/src/api-requests/data-provider.ts
@@ -104,12 +104,16 @@ export const makeTemplateRequests = async (signedApiUpdate: SignedApiUpdate): Pr
       endpointParameters
     );
     const goEncodedResponse = goSync(() => {
-      return extractAndEncodeResponse(goPostProcess.data.response, {
-        _type,
-        _path,
-        _times,
-      });
+      return {
+        timestamp: (goPostProcess.data.timestamp ?? Math.floor(Date.now() / 1000)).toString(),
+        encodedResponse: extractAndEncodeResponse(goPostProcess.data.response, {
+          _type,
+          _path,
+          _times,
+        }),
+      };
     });
+
     if (!goEncodedResponse.success) {
       logger.error(`Failed to encode response.`, {
         templateId,

--- a/packages/airnode-feed/src/heartbeat/heartbeat.test.ts
+++ b/packages/airnode-feed/src/heartbeat/heartbeat.test.ts
@@ -14,7 +14,7 @@ import { initiateHeartbeatLoop, logHeartbeat } from '.';
 
 // eslint-disable-next-line jest/no-hooks
 beforeEach(() => {
-  jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-20')); // 1674172800
 });
 
 afterEach(() => {

--- a/packages/airnode-feed/src/sign-template-data.test.ts
+++ b/packages/airnode-feed/src/sign-template-data.test.ts
@@ -11,7 +11,7 @@ describe(signTemplateResponses.name, () => {
   it('signs template responses', async () => {
     const state = stateModule.getInitialState(config);
     jest.spyOn(stateModule, 'getState').mockReturnValue(state);
-    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20')); // 1674172800
 
     const signedTemplateResponses = await signTemplateResponses(nodaryTemplateResponses);
 

--- a/packages/airnode-feed/src/state.test.ts
+++ b/packages/airnode-feed/src/state.test.ts
@@ -46,7 +46,7 @@ describe(DelayedSignedDataQueue.name, () => {
   });
 
   it('can prune unused data', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20')); // 1674172800
 
     const queue = new DelayedSignedDataQueue(30);
     const data3 = nodarySignedTemplateResponses[0]![1];
@@ -63,7 +63,7 @@ describe(DelayedSignedDataQueue.name, () => {
   });
 
   it('keeps data in the queue if none of the items exceed maxUpdateDelay', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2023-01-20'));
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-20')); // 1674172800
     const queue = new DelayedSignedDataQueue(30);
     const data = nodarySignedTemplateResponses[0]![1];
     const timestamp = Number.parseInt(data.timestamp, 10);

--- a/packages/airnode-feed/test/fixtures.ts
+++ b/packages/airnode-feed/test/fixtures.ts
@@ -127,25 +127,34 @@ export const nodaryTemplateResponses: TemplateResponse[] = [
   [
     '0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd',
     {
-      encodedValue: '0x000000000000000000000000000000000000000000000004d3f4ae23d04a0000',
-      rawValue: 89.06,
-      values: ['89060000000000000000'],
+      timestamp: '1674172800',
+      encodedResponse: {
+        encodedValue: '0x000000000000000000000000000000000000000000000004d3f4ae23d04a0000',
+        rawValue: 89.06,
+        values: ['89060000000000000000'],
+      },
     },
   ],
   [
     '0x086130c54864b2129f8ac6d8d7ab819fa8181bbe676e35047b1bca4c31d51c66',
     {
-      encodedValue: '0x0000000000000000000000000000000000000000000000013f6697ef5acf2000',
-      rawValue: 23.015_25,
-      values: ['23015250000000000000'],
+      timestamp: '1674172800',
+      encodedResponse: {
+        encodedValue: '0x0000000000000000000000000000000000000000000000013f6697ef5acf2000',
+        rawValue: 23.015_25,
+        values: ['23015250000000000000'],
+      },
     },
   ],
   [
     '0x1d65c1f1e127a41cebd2339f823d0290322c63f3044380cbac105db8e522ebb9',
     {
-      encodedValue: '0x000000000000000000000000000000000000000000000067ac3a7509c06a8000',
-      rawValue: 1912.425,
-      values: ['1912425000000000000000'],
+      timestamp: '1674172800',
+      encodedResponse: {
+        encodedValue: '0x000000000000000000000000000000000000000000000067ac3a7509c06a8000',
+        rawValue: 1912.425,
+        values: ['1912425000000000000000'],
+      },
     },
   ],
 ];

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -8,7 +8,7 @@
    `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`. If you are using Docker Desktop, you need to change
    the URL in `airnode-feed/secrets.env` from `localhost` to `host.docker.internal`, because Airnode feed is running
    inside a Docker container.
-2. Copy the Signed API secrets. Whilst inside `src` run run `cp signed-api/secrets.example.env signed-api/secrets.env`
+2. Copy the Signed API secrets. Whilst inside `src` run `cp signed-api/secrets.example.env signed-api/secrets.env`
 3. Build the latest Docker images. Run `pnpm run docker:build` from the monorepo root. The e2e flow uses the docker
    images.
 4. This module contains services (or configurations) that are integrated together. Specifically:

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -4,9 +4,9 @@
 
 ## Getting started
 
-1. Copy the Airnode feed secrets. Run `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`. If you are using
-   Docker Desktop, you need to change the URL in `airnode-feed/secrets.env` from `localhost` to `host.docker.internal`,
-   because Airnode feed is running inside a Docker container.
+1. Copy the Airnode feed secrets. Whilst inside `src` run `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`.
+   If you are using Docker Desktop, you need to change the URL in `airnode-feed/secrets.env` from `localhost` to
+   `host.docker.internal`, because Airnode feed is running inside a Docker container.
 2. Copy the Signed API secrets. Run `cp signed-api/secrets.example.env signed-api/secrets.env`
 3. Build the latest Docker images. Run `pnpm run docker:build` from the monorepo root. The e2e flow uses the docker
    images.

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -8,7 +8,7 @@
    `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`. If you are using Docker Desktop, you need to change
    the URL in `airnode-feed/secrets.env` from `localhost` to `host.docker.internal`, because Airnode feed is running
    inside a Docker container.
-2. Copy the Signed API secrets. Run `cp signed-api/secrets.example.env signed-api/secrets.env`
+2. Copy the Signed API secrets. Whilst inside `src` run run `cp signed-api/secrets.example.env signed-api/secrets.env`
 3. Build the latest Docker images. Run `pnpm run docker:build` from the monorepo root. The e2e flow uses the docker
    images.
 4. This module contains services (or configurations) that are integrated together. Specifically:

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -4,9 +4,10 @@
 
 ## Getting started
 
-1. Copy the Airnode feed secrets. Whilst inside `src` run `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`.
-   If you are using Docker Desktop, you need to change the URL in `airnode-feed/secrets.env` from `localhost` to
-   `host.docker.internal`, because Airnode feed is running inside a Docker container.
+1. Copy the Airnode feed secrets. Whilst inside `src` run
+   `cp airnode-feed/secrets.example.env airnode-feed/secrets.env`. If you are using Docker Desktop, you need to change
+   the URL in `airnode-feed/secrets.env` from `localhost` to `host.docker.internal`, because Airnode feed is running
+   inside a Docker container.
 2. Copy the Signed API secrets. Run `cp signed-api/secrets.example.env signed-api/secrets.env`
 3. Build the latest Docker images. Run `pnpm run docker:build` from the monorepo root. The e2e flow uses the docker
    images.

--- a/packages/e2e/src/airnode-feed/secrets.example.env
+++ b/packages/e2e/src/airnode-feed/secrets.example.env
@@ -1,3 +1,3 @@
-# Use "host.docker.internal" if using Docker for Desktop, otherwise laeve it set to "localhost".
+# Use "host.docker.internal" if using Docker for Desktop, otherwise leave it set to "localhost".
 SIGNED_API_URL=http://localhost:8090
 DATA_PROVIDER_API=http://localhost:9876


### PR DESCRIPTION
Timestamps returned from post-processing V2 were being discarded. 
This follows the behaviour of Airnode in that if a post-processing-supplied timestamp is available, it will be used, otherwise it will fall back to the system clock.

Closes #228 

@Ashar2shahid, can you test this branch? You can do so by cloning it and building the docker images locally (`pnpm docker:build`)