### PR TITLE
Ignore casing when comparing address

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { join } = require('node:path');
 
-/*
+/**
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
  */

--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -1,6 +1,21 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const config = require('../../jest.config');
+const { join } = require('node:path');
 
+/**
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
 module.exports = {
-  ...config,
+  collectCoverage: false, // It doesn't make sense to collect coverage for e2e tests because they target high level features and interaction with other services.
+  maxWorkers: 1, // We don't want to run tests in parallel because they might interfere with each other. This option is the same as --runInBand. See: https://stackoverflow.com/a/46489246.
+
+  preset: 'ts-jest',
+  resetMocks: true,
+  restoreMocks: true,
+  setupFiles: [join(__dirname, '../../jest.setup.js')],
+  testEnvironment: 'jest-environment-node',
+  testMatch: ['**/?(*.)+(feature).[t]s?(x)'],
+  testPathIgnorePatterns: ['<rootDir>/.build', '<rootDir>/dist/', '<rootDir>/build/'],
+  testTimeout: 40_000,
+  verbose: true,
 };

--- a/packages/e2e/src/signed-api/signed-api.json
+++ b/packages/e2e/src/signed-api/signed-api.json
@@ -12,7 +12,8 @@
     }
   ],
   "allowedAirnodes": [
-    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"] }
+    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"] },
+    { "address": "0xA840740650b832B9480EE56d4e3641f5E57DDE3E", "authTokens": null }
   ],
   "stage": "e2e-test",
   "version": "0.6.0"

--- a/packages/e2e/src/utils.ts
+++ b/packages/e2e/src/utils.ts
@@ -19,3 +19,52 @@ export const formatData = (networkResponse: any) => {
 export const airnode = ethers.Wallet.fromMnemonic(
   'diamond result history offer forest diagram crop armed stumble orchard stage glance'
 ).address;
+
+export const deriveBeaconId = (airnode: string, templateId: string) =>
+  ethers.utils.keccak256(ethers.utils.solidityPack(['address', 'bytes32'], [airnode, templateId]));
+
+export const deriveTemplateId = (endpointId: string, encodedParameters: string) =>
+  ethers.utils.keccak256(ethers.utils.solidityPack(['bytes32', 'bytes'], [endpointId, encodedParameters]));
+
+export const generateRandomBytes = (len: number) => ethers.utils.hexlify(ethers.utils.randomBytes(len));
+
+export const generateRandomWallet = () => ethers.Wallet.createRandom();
+
+export const generateRandomEvmAddress = () => generateRandomWallet().address;
+
+// NOTE: This function (and related helpers) are copied over from signed-api project. Ideally, these would come from
+// commons.
+export const generateDataSignature = async (
+  wallet: ethers.Wallet,
+  templateId: string,
+  timestamp: string,
+  data: string
+) => {
+  return wallet.signMessage(
+    ethers.utils.arrayify(
+      ethers.utils.keccak256(
+        ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data || '0x'])
+      )
+    )
+  );
+};
+
+export const createSignedData = async (
+  airnodeWallet: ethers.Wallet,
+  timestamp: string = Math.floor(Date.now() / 1000).toString()
+) => {
+  const airnode = airnodeWallet.address;
+  const templateId = generateRandomBytes(32);
+  const beaconId = deriveBeaconId(airnode, templateId);
+  const encodedValue = '0x00000000000000000000000000000000000000000000005718e3a22ce01f7a40';
+  const signature = await generateDataSignature(airnodeWallet, templateId, timestamp, encodedValue);
+
+  return {
+    airnode,
+    templateId,
+    beaconId,
+    timestamp,
+    encodedValue,
+    signature,
+  };
+};

--- a/packages/e2e/test/signed-api.feature.ts
+++ b/packages/e2e/test/signed-api.feature.ts
@@ -2,7 +2,7 @@ import { go } from '@api3/promise-utils';
 import axios from 'axios';
 import { ethers } from 'ethers';
 
-import { airnode, createSignedData, formatData } from './utils';
+import { airnode, createSignedData, formatData } from '../src/utils';
 
 test('respects the delay', async () => {
   const start = Date.now();

--- a/packages/signed-api/src/schema.ts
+++ b/packages/signed-api/src/schema.ts
@@ -1,10 +1,23 @@
 import { type LogFormat, logFormatOptions, logLevelOptions, type LogLevel } from '@api3/commons';
+import { goSync } from '@api3/promise-utils';
+import { ethers } from 'ethers';
 import { uniqBy } from 'lodash';
 import { z } from 'zod';
 
 import packageJson from '../package.json';
 
-export const evmAddressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
+export const evmAddressSchema = z.string().transform((val, ctx) => {
+  const goChecksumAddress = goSync(() => ethers.utils.getAddress(val));
+  if (!goChecksumAddress.success) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Invalid EVM address',
+      path: [],
+    });
+    return '';
+  }
+  return goChecksumAddress.data;
+});
 
 export const evmIdSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM ID');
 


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/248

## Rationale

Make sure the Airnode address is checksummed before checking if it's valid. I think the nicest solution is to let it be checksummed by making a zod transformation. Initially, I wanted to lowercase this (in Auctioneer), but the problem is that addresses coming from web3 clients are checksummed (ethers, viem...) so it makes more sense to checksum them. This is something that should be included in https://github.com/api3dao/commons.