### PR TITLE
Remove extraneous config validation fields

### DIFF
--- a/packages/airnode-feed/config/configuration.md
+++ b/packages/airnode-feed/config/configuration.md
@@ -246,7 +246,7 @@ The name of the signed API.
 
 The URL of the signed API.
 
-### `authToken`
+#### `authToken`
 
 The authentication token used to authenticate with the signed API. It is recommended to interpolate this value from
 secrets.

--- a/packages/airnode-feed/src/validation/schema.ts
+++ b/packages/airnode-feed/src/validation/schema.ts
@@ -270,10 +270,7 @@ export type NodeSettings = z.infer<typeof nodeSettingsSchema>;
 export const configSchema = z
   .strictObject({
     apiCredentials: apisCredentialsSchema,
-    beaconSets: z.any(),
-    chains: z.any(),
     endpoints: endpointsSchema,
-    gateways: z.any(),
     nodeSettings: nodeSettingsSchema,
     ois: oisesSchema,
     signedApis: signedApisSchema,


### PR DESCRIPTION
These are invalid as per https://github.com/api3dao/signed-api/blob/remove-invalid-config-field/packages/airnode-feed/configuration.md?plain=1#L86