### PR TITLE
Disable node docker update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dependencies"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "enabled": false
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
I want to prevent renovate from creating [these](https://github.com/api3dao/signed-api/pull/322) PRs.