### PR TITLE
Expose unsigned data

### DIFF
--- a/packages/airnode-feed/config/airnode-feed.example.json
+++ b/packages/airnode-feed/config/airnode-feed.example.json
@@ -35,7 +35,7 @@
     {
       "name": "localhost",
       "url": "http://localhost:8090",
-      "authToken": "some-secret-token-for-airnode-feed"
+      "authToken": "${AIRNODE_FEED_AUTH_TOKEN}"
     }
   ],
   "ois": [

--- a/packages/airnode-feed/config/secrets.example.env
+++ b/packages/airnode-feed/config/secrets.example.env
@@ -2,3 +2,5 @@
 WALLET_MNEMONIC=diamond result history offer forest diagram crop armed stumble orchard stage glance
 # Get it from core development team, otherwise you can use some publicly available data provider API instead of Nodary.
 NODARY_API_KEY=
+# The Signed API auth token allowing this Airnode feed to push the signed data.
+AIRNODE_FEED_AUTH_TOKEN=some-secret-token-for-airnode-feed

--- a/packages/signed-api/config/configuration.md
+++ b/packages/signed-api/config/configuration.md
@@ -120,7 +120,7 @@ You are advised to put sensitive information inside secrets file.
 The API needs to be configured with endpoints to be served. This is done via the `endpoints` section. For example:
 
 ```jsonc
-// Defines two endpoints.
+// Defines three endpoints.
 "endpoints": [
   // Serves the non-delayed data on URL path "/real-time". Requesters need to provide the "some-secret-token" as Bearer token.
   {
@@ -133,6 +133,13 @@ The API needs to be configured with endpoints to be served. This is done via the
     "urlPath": "/delayed",
     "delaySeconds": 15,
     "authTokens": null,
+  },
+  // Serve the unsigned data in real-time on URL path "/unsigned-real-time". No authentication is required.
+  {
+    "urlPath": "/unsigned-real-time",
+    "authTokens": null,
+    "delaySeconds": 0,
+    "hideSignatures": true
   }
 ]
 ```
@@ -157,6 +164,11 @@ The nonempty list of
 the data.
 
 In case the endpoint should be publicly available, set the value to `null`.
+
+##### `hideSignatures` _(optional)_
+
+The boolean flag to hide the signatures in the response. The flag is optional for backwards compatibility with older
+Signed API versions.
 
 ### `cache` _(optional)_
 

--- a/packages/signed-api/config/secrets.example.env
+++ b/packages/signed-api/config/secrets.example.env
@@ -1,2 +1,2 @@
 REAL_TIME_ENDPOINT_AUTH_TOKEN=secret-endpoint-token
-AIRNODE_FEED_AUTH_TOKEN=secret-airnode-token
+AIRNODE_FEED_AUTH_TOKEN=some-secret-token-for-airnode-feed

--- a/packages/signed-api/config/signed-api.example.json
+++ b/packages/signed-api/config/signed-api.example.json
@@ -9,6 +9,12 @@
       "urlPath": "/delayed",
       "authTokens": null,
       "delaySeconds": 15
+    },
+    {
+      "urlPath": "/unsigned-real-time",
+      "authTokens": null,
+      "delaySeconds": 0,
+      "hideSignatures": true
     }
   ],
   "allowedAirnodes": [

--- a/packages/signed-api/src/handlers.ts
+++ b/packages/signed-api/src/handlers.ts
@@ -143,7 +143,7 @@ export const getData = (
   }
   const airnodeAddress = goAirnodeAddresses.data;
 
-  const { delaySeconds, authTokens } = endpoint;
+  const { delaySeconds, authTokens, hideSignatures } = endpoint;
   const authToken = extractBearerToken(authorizationHeader);
   if (authTokens !== null && !authTokens.includes(authToken!)) {
     return generateErrorResponse(403, 'Invalid auth token', { authToken });
@@ -157,7 +157,8 @@ export const getData = (
   const ignoreAfterTimestamp = Math.floor(Date.now() / 1000 - delaySeconds);
   const cachedValues = getAll(airnodeAddress, ignoreAfterTimestamp);
   const data = cachedValues.reduce((acc, signedData) => {
-    return { ...acc, [signedData.beaconId]: omit(signedData, 'beaconId') };
+    const data = hideSignatures ? omit(signedData, 'beaconId', 'signature') : omit(signedData, 'beaconId');
+    return { ...acc, [signedData.beaconId]: data };
   }, {});
 
   return {

--- a/packages/signed-api/src/schema.ts
+++ b/packages/signed-api/src/schema.ts
@@ -27,6 +27,7 @@ export const endpointSchema = z.strictObject({
     .regex(/^\/[\dA-Za-z-]+$/, 'Must start with a slash and contain only alphanumeric characters and dashes'),
   authTokens: z.array(z.string()).nonempty().nullable(),
   delaySeconds: z.number().nonnegative().int(),
+  hideSignatures: z.boolean().default(false),
 });
 
 export type Endpoint = z.infer<typeof endpointSchema>;


### PR DESCRIPTION
Closes https://github.com/api3dao/signed-api/issues/325

An example response from the API:
```
{"count":3,"data":{"0xebba8507d616ed80766292d200a3598fdba656d9938cecc392765d4a284a69a4":{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","templateId":"0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd","timestamp":"1719819852","encodedValue":"0x0000000000000000000000000000000000000000000000047432f4b29a180000"},"0x6f6acbdadaaf116c89faf0e8de1d0c7c2352b01cce7be0eb9deb126ceaefa6ba":{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","templateId":"0x086130c54864b2129f8ac6d8d7ab819fa8181bbe676e35047b1bca4c31d51c66","timestamp":"1719819852","encodedValue":"0x000000000000000000000000000000000000000000000001944d352591748000"},"0x7944f22b40cc691a003e35db4810b41543a83781d94f706b5c0b6980e0a06ed7":{"airnode":"0xbF3137b0a7574563a23a8fC8badC6537F98197CC","templateId":"0x1d65c1f1e127a41cebd2339f823d0290322c63f3044380cbac105db8e522ebb9","timestamp":"1719819852","encodedValue":"0x00000000000000000000000000000000000000000000007e1a3b815ec22a0000"}}}
```

The response is identical to the full Signed data, except the signature is omitted, making the data unusable for base fee updates.

Note, that this makes it awkward for [typing the return response](https://github.com/api3dao/signed-api/issues/306), but the caller will know whether they query the full or unsigned data endpoint, so this should not be an issue. This feature will also be superceded by https://github.com/api3dao/signed-api/issues/327