### PR TITLE
Enable `automerge` for Renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "ts-jest": "^29.2.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "pnpm@9.7.0+sha512.dc09430156b427f5ecfc79888899e1c39d2d690f004be70e05230b72cb173d96839587545d09429b55ac3c429c801b4dc3c0e002f653830a420fa2dd4e3cf9cf"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "reviewers": ["Siegrift", "aquarat", "mcoetzee", "andreogle"],
+  "reviewers": ["Siegrift"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "dependencyDashboard": false

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "reviewers": ["Siegrift"],
   "minimumReleaseAge": "7 days",

--- a/renovate.json
+++ b/renovate.json
@@ -27,9 +27,10 @@
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": false
+    "enabled": true,
+    "automerge": true
   },
-  "reviewers": ["Siegrift"],
+  "reviewers": ["Siegrift", "aquarat", "mcoetzee", "andreogle"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "dependencyDashboard": false

--- a/renovate.json
+++ b/renovate.json
@@ -11,13 +11,15 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
-      "groupName": "non-major-devDependencies"
+      "groupName": "non-major-devDependencies",
+      "automerge": true
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
-      "groupName": "non-major-dependencies"
+      "groupName": "non-major-dependencies",
+      "automerge": true
     },
     {
       "matchDatasources": ["docker"],
@@ -27,8 +29,7 @@
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
+    "enabled": true
   },
   "reviewers": ["Siegrift", "aquarat", "mcoetzee", "andreogle"],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
As requested by Siegrief this enables Renovate `automerge` for minor and patch dependency updates. It also adds more team members as reviewers.

Closes https://github.com/api3dao/signed-api/issues/352