### PR TITLE
Add `/status` endpoint and specify certified airnode addresses

### DIFF
--- a/packages/e2e/src/signed-api/signed-api.json
+++ b/packages/e2e/src/signed-api/signed-api.json
@@ -20,8 +20,12 @@
     }
   ],
   "allowedAirnodes": [
-    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"] },
-    { "address": "0xA840740650b832B9480EE56d4e3641f5E57DDE3E", "authTokens": null }
+    {
+      "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
+      "isCertified": true,
+      "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"]
+    },
+    { "address": "0xA840740650b832B9480EE56d4e3641f5E57DDE3E", "isCertified": false, "authTokens": null }
   ],
   "stage": "e2e-test",
   "version": "2.1.0"

--- a/packages/signed-api/config/configuration.md
+++ b/packages/signed-api/config/configuration.md
@@ -219,14 +219,14 @@ or
 
 ```jsonc
 // Allows pushing signed data only for the specific Airnode. No authorization is required to push the data.
-"allowedAirnodes": [ { "address": "0xB47E3D8734780430ee6EfeF3c5407090601Dcd15", "authTokens": null } ]
+"allowedAirnodes": [ { "address": "0xB47E3D8734780430ee6EfeF3c5407090601Dcd15", "authTokens": null, "isCertified": true } ]
 ```
 
 or
 
 ```jsonc
 // Allows pushing signed data only for the specific Airnode. The pusher needs to authorize with one of the specific tokens.
-"allowedAirnodes": { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["some-secret-token-for-airnode-feed"] }
+"allowedAirnodes": { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["some-secret-token-for-airnode-feed"], "isCertified": true }
 ```
 
 #### `allowedAirnodes[n]`
@@ -244,6 +244,12 @@ The nonempty list of
 
 To allow pushing data without any authorization, set the value to `null`. The API validates the data, but this is not
 recommended.
+
+##### `isCertified`
+
+A boolean flag indicating whether the Airnode is first-party verified. When set to true, the Airnode address will be
+included in the `/status` endpoint response under `certifiedAirnodeAddresses`. This proves that the deployer of the
+Signed API instance owns/controls these Airnodes, enabling clients to verify first-party data sources.
 
 #### `stage`
 

--- a/packages/signed-api/config/signed-api.example.json
+++ b/packages/signed-api/config/signed-api.example.json
@@ -27,7 +27,11 @@
     }
   ],
   "allowedAirnodes": [
-    { "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC", "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"] }
+    {
+      "address": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
+      "authTokens": ["${AIRNODE_FEED_AUTH_TOKEN}"],
+      "isCertified": true
+    }
   ],
   "stage": "local",
   "version": "2.1.0"

--- a/packages/signed-api/src/handlers.test.ts
+++ b/packages/signed-api/src/handlers.test.ts
@@ -14,12 +14,12 @@ import {
 
 import * as configModule from './config/config';
 import * as envModule from './env';
-import { batchInsertData, getData, listAirnodeAddresses } from './handlers';
+import { batchInsertData, getData, getStatus, listAirnodeAddresses } from './handlers';
 import * as inMemoryCacheModule from './in-memory-cache';
 import { logger } from './logger';
 import { type EnvConfig } from './schema';
 import { initializeVerifierPool } from './signed-data-verifier-pool';
-import { type ApiResponse } from './types';
+import type { ApiResponse, GetStatusResponseSchema } from './types';
 import { deriveBeaconId } from './utils';
 
 let workerPool: Pool;
@@ -554,5 +554,106 @@ describe(listAirnodeAddresses.name, () => {
       count: 1,
       'available-airnodes': [airnodeWallet.address],
     });
+  });
+});
+
+describe(getStatus.name, () => {
+  const mockDate = new Date('2024-01-01T00:00:00Z');
+  const mockTimestamp = Math.floor(mockDate.getTime() / 1000).toString();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns empty certified airnode addresses when config has "*"', () => {
+    const config = getMockedConfig();
+    config.allowedAirnodes = '*';
+    jest.spyOn(configModule, 'getConfig').mockReturnValue(config);
+
+    const result = getStatus();
+    const { body, statusCode } = parseResponse<GetStatusResponseSchema>(result);
+
+    expect(statusCode).toBe(200);
+    expect(body).toStrictEqual({
+      certifiedAirnodeAddresses: [],
+      stage: config.stage,
+      version: config.version,
+      currentTimestamp: mockTimestamp,
+      deploymentTimestamp: expect.any(String),
+      configHash: expect.any(String),
+    });
+  });
+
+  it('returns certified airnode addresses when config has specific airnodes', () => {
+    const config = getMockedConfig();
+    config.allowedAirnodes = [
+      { address: '0xA0342Ba0319c0bCd66E770d74489aA2997a54bFb', authTokens: ['token1'], isCertified: true },
+      { address: '0x27f093777962Bb743E6cAC44cd724B84B725408a', authTokens: null, isCertified: false },
+    ];
+    jest.spyOn(configModule, 'getConfig').mockReturnValue(config);
+
+    const result = getStatus();
+    const { body, statusCode } = parseResponse<GetStatusResponseSchema>(result);
+
+    expect(statusCode).toBe(200);
+    expect(body).toStrictEqual({
+      certifiedAirnodeAddresses: ['0xA0342Ba0319c0bCd66E770d74489aA2997a54bFb'],
+      stage: config.stage,
+      version: config.version,
+      currentTimestamp: mockTimestamp,
+      deploymentTimestamp: expect.any(String),
+      configHash: expect.any(String),
+    });
+  });
+
+  it('generates consistent configHash for same config', () => {
+    const config = getMockedConfig();
+    jest.spyOn(configModule, 'getConfig').mockReturnValue(config);
+
+    const result1 = getStatus();
+    const result2 = getStatus();
+
+    const body1 = parseResponse<GetStatusResponseSchema>(result1).body;
+    const body2 = parseResponse<GetStatusResponseSchema>(result2).body;
+
+    expect(body1.configHash).toBe(body2.configHash);
+  });
+
+  it('generates different configHash for different configs', () => {
+    const config1 = getMockedConfig();
+    const config2 = { ...getMockedConfig(), stage: 'different-stage' };
+
+    jest.spyOn(configModule, 'getConfig').mockReturnValueOnce(config1).mockReturnValueOnce(config2);
+
+    const result1 = getStatus();
+    const result2 = getStatus();
+
+    const body1 = parseResponse<GetStatusResponseSchema>(result1).body;
+    const body2 = parseResponse<GetStatusResponseSchema>(result2).body;
+
+    expect(body1.configHash).not.toBe(body2.configHash);
+  });
+
+  it('maintains same deploymentTimestamp across multiple calls', () => {
+    const config = getMockedConfig();
+    jest.spyOn(configModule, 'getConfig').mockReturnValue(config);
+
+    const result1 = getStatus();
+
+    // Advance time by 1 hour
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    const result2 = getStatus();
+
+    const body1 = parseResponse<GetStatusResponseSchema>(result1).body;
+    const body2 = parseResponse<GetStatusResponseSchema>(result2).body;
+
+    expect(body1.deploymentTimestamp).toBe(body2.deploymentTimestamp);
+    expect(body1.currentTimestamp).not.toBe(body2.currentTimestamp);
   });
 });

--- a/packages/signed-api/src/handlers.ts
+++ b/packages/signed-api/src/handlers.ts
@@ -1,4 +1,5 @@
 import { signedApiBatchPayloadV1Schema, signedApiBatchPayloadV2Schema } from '@api3/airnode-feed';
+import { createSha256Hash, serializePlainObject } from '@api3/commons';
 import { go, goSync } from '@api3/promise-utils';
 import { isEmpty, omit, pick } from 'lodash';
 
@@ -17,10 +18,14 @@ import type {
   GetUnsignedDataResponseSchema,
   InternalSignedData,
   PostSignedDataResponseSchema,
+  GetStatusResponseSchema,
 } from './types';
 import { extractBearerToken, generateErrorResponse, isBatchUnique } from './utils';
 
 const LOG_API_DATA_DELAY_MS = 5 * 60 * 1000;
+
+// Initialize deployment timestamp when the application starts
+const DEPLOYMENT_TIMESTAMP = Math.floor(Date.now() / 1000).toString();
 
 // Accepts a batch of signed data that is first validated for consistency and data integrity errors. If there is any
 // issue during this step, the whole batch is rejected.
@@ -217,6 +222,33 @@ export const listAirnodeAddresses = async (): Promise<ApiResponse> => {
   return {
     statusCode: 200,
     headers: createResponseHeaders(getConfig().cache),
+    body: JSON.stringify(response),
+  };
+};
+
+export const getStatus = (): ApiResponse => {
+  const config = getConfig();
+  const configHash = createSha256Hash(serializePlainObject(config));
+  const currentTimestamp = Math.floor(Date.now() / 1000).toString();
+
+  // Get certified airnode addresses from config
+  const certifiedAirnodeAddresses =
+    config.allowedAirnodes === '*'
+      ? []
+      : config.allowedAirnodes.filter((airnode) => airnode.isCertified).map((airnode) => airnode.address);
+
+  const response: GetStatusResponseSchema = {
+    stage: config.stage,
+    version: config.version,
+    currentTimestamp,
+    deploymentTimestamp: DEPLOYMENT_TIMESTAMP,
+    configHash,
+    certifiedAirnodeAddresses,
+  };
+
+  return {
+    statusCode: 200,
+    headers: createResponseHeaders(config.cache),
     body: JSON.stringify(response),
   };
 };

--- a/packages/signed-api/src/schema.test.ts
+++ b/packages/signed-api/src/schema.test.ts
@@ -139,8 +139,8 @@ describe('allowed Airnodes schema', () => {
 
     expect(() =>
       allowedAirnodesSchema.parse([
-        { address: '0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', authTokens: ['token1'] },
-        { address: '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11', authTokens: null },
+        { address: '0xB47E3D8734780430ee6EfeF3c5407090601Dcd15', isCertified: true, authTokens: ['token1'] },
+        { address: '0xE1d8E71195606Ff69CA33A375C31fe763Db97B11', isCertified: false, authTokens: null },
       ])
     ).not.toThrow();
   });

--- a/packages/signed-api/src/schema.ts
+++ b/packages/signed-api/src/schema.ts
@@ -43,6 +43,7 @@ export const endpointsSchema = z
 const allowedAirnodeSchema = z.strictObject({
   address: evmAddressSchema,
   authTokens: z.array(z.string()).nonempty().nullable(),
+  isCertified: z.boolean(),
 });
 
 export type AllowedAirnode = z.infer<typeof allowedAirnodeSchema>;

--- a/packages/signed-api/src/server.ts
+++ b/packages/signed-api/src/server.ts
@@ -1,7 +1,7 @@
 import { go } from '@api3/promise-utils';
 import express from 'express';
 
-import { getData, listAirnodeAddresses, batchInsertData } from './handlers';
+import { getData, getStatus, listAirnodeAddresses, batchInsertData } from './handlers';
 import { logger } from './logger';
 import type { Config } from './schema';
 
@@ -38,6 +38,19 @@ export const startServer = (config: Config, port: number) => {
       res.status(result.statusCode).header(result.headers).send(result.body);
 
       logger.debug('Responded to request "GET /".', result);
+    });
+
+    if (!goRequest.success) next(goRequest.error);
+  });
+
+  app.get('/status', async (_req, res, next) => {
+    const goRequest = await go(() => {
+      logger.info('Received request "GET /status".');
+
+      const result = getStatus();
+      res.status(result.statusCode).header(result.headers).send(result.body);
+
+      logger.debug('Responded to request "GET /status".', result);
     });
 
     if (!goRequest.success) next(goRequest.error);

--- a/packages/signed-api/src/types.ts
+++ b/packages/signed-api/src/types.ts
@@ -21,6 +21,15 @@ export type PostSignedDataResponseSchema = {
 
 export type GetListAirnodesResponseSchema = { count: number; 'available-airnodes': string[] };
 
+export type GetStatusResponseSchema = {
+  stage: string;
+  version: string;
+  currentTimestamp: string;
+  deploymentTimestamp: string;
+  configHash: string;
+  certifiedAirnodeAddresses: string[];
+};
+
 export type InternalSignedData = {
   airnode: string;
   templateId: string;


### PR DESCRIPTION
Closes #397 
Closes #406 

Unlike the https://github.com/api3dao/signed-api/issues/406, I listed only `certifiedAirnodeAddresses` (airnodes with `isCertified: true`) since we don’t need signed-api config details. The goal is to verify first-party Airnodes, and the market only requires certified addresses.