### PR TITLE
Suppress redundant logging from dotenv

### DIFF
--- a/packages/airnode-feed/src/validation/env.ts
+++ b/packages/airnode-feed/src/validation/env.ts
@@ -10,7 +10,7 @@ let env: EnvConfig | undefined;
 export const loadEnv = () => {
   if (env) return env;
 
-  dotenv.config({ path: join(__dirname, '../../.env') });
+  dotenv.config({ path: join(__dirname, '../../.env'), quiet: true });
 
   const parseResult = envConfigSchema.safeParse(process.env);
   if (!parseResult.success) {

--- a/packages/signed-api/src/env.ts
+++ b/packages/signed-api/src/env.ts
@@ -10,7 +10,7 @@ let env: EnvConfig | undefined;
 export const loadEnv = () => {
   if (env) return env;
 
-  dotenv.config({ path: join(__dirname, '../.env') });
+  dotenv.config({ path: join(__dirname, '../.env'), quiet: true });
 
   const parseResult = envConfigSchema.safeParse(process.env);
   if (!parseResult.success) {


### PR DESCRIPTION
Adds `quiet: true` to `dotenv.config()` in `airnode-feed` and `signed-api` to suppress the noisy log message:

```
[dotenv@17.2.3] injecting env (0) from dist/.env -- tip: ⚙️  enable debug logging with { debug: true }
```

This output adds no value when env vars are already injected directly via Docker/CI.

Closes #551
